### PR TITLE
Add plain text parser and enable .txt, .html, and .md file ingest

### DIFF
--- a/app/services/parsers.rb
+++ b/app/services/parsers.rb
@@ -1,7 +1,9 @@
 module Parsers
 
   def self.parser_for(filename)
-    return Parsers::Pdf if filename.downcase.end_with?(".pdf")
+    name_locase = filename.downcase
+    return Parsers::Pdf if name_locase.end_with?(".pdf")
+    return Parsers::Text if name_locase.end_with?(".txt", ".html", ".md")
 
     raise StandardError, "Unsupported file extension: '#{filename.slice(/\.\w+$/)}'"
   end

--- a/app/services/parsers/text.rb
+++ b/app/services/parsers/text.rb
@@ -1,0 +1,12 @@
+module Parsers
+  class Text
+    def initialize(document)
+      @document = document
+    end
+
+    def text
+      @text ||= @document.contents
+    end
+
+  end
+end


### PR DESCRIPTION
Super simple, just returns document contents as text. Mapped to text, html, and markdown file extensions.