### PR TITLE
Start moving chunking into parser land.

### DIFF
--- a/app/services/chonker.rb
+++ b/app/services/chonker.rb
@@ -1,4 +1,7 @@
 class Chonker
+  # implement basic text chunker until all parsers will be self-chunking
+  include Parsers::BasicTextChunker
+
   class UnknownChunkingMethod < StandardError; end
 
   CHUNKING_METHODS = {
@@ -16,43 +19,11 @@ class Chonker
   def chunks
     raise UnknownChunkingMethod, "Unknown chunking method '#{@profile.method}'" unless CHUNKING_METHODS[@profile.method]
 
-    send(CHUNKING_METHODS[@profile.method])
+    chunker = (@parser.is_a?(Parsers::SelfChunker) && @parser) || self
+    chunker.send(CHUNKING_METHODS[@profile.method], @profile)
   end
 
   private
-
-  def chunk_by_bytes
-    chunk_size = @profile.size
-
-    chunks = text.gsub(/  +/, "  ").gsub(/\n\n+/, "\n\n").scan(/.{0,#{chunk_size}}\b /m)
-
-    overlapped_chunks(chunks)
-  end
-
-  def overlapped_chunks(chunks)
-    chunk_overlap = @profile.overlap
-    overlapped_chunks = []
-
-    chunks.each_with_index do |chunk, idx|
-      prev_chunk = chunks[idx - 1] if idx.positive?
-      next_chunk = chunks[idx + 1] if idx < (chunks.length - 1)
-
-      # TODO: this is horribly inefficient - stop copying so much string data around
-      if prev_chunk
-        ending_of_prev_chunk = prev_chunk.match(/\b(.{1,#{chunk_overlap}})\Z/m)
-        chunk = "#{ending_of_prev_chunk[1] if ending_of_prev_chunk}#{chunk}"
-      end
-
-      if next_chunk
-        beginning_of_next_chunk = next_chunk.match(/^(.{1,#{chunk_overlap}})\b/)
-        chunk = "#{chunk}#{beginning_of_next_chunk[1] if beginning_of_next_chunk}"
-      end
-
-      overlapped_chunks << chunk
-    end
-
-    overlapped_chunks
-  end
 
   def text
     @text ||= @parser.text.dup

--- a/app/services/chonker.rb
+++ b/app/services/chonker.rb
@@ -9,19 +9,24 @@ class Chonker
     "pages" => :chunk_by_pages,
   }.freeze
 
-  def initialize(parser, profile)
+  def initialize(parser)
     @parser = parser
-    @profile = profile
   end
 
   def chunks
-    raise UnknownChunkingMethod, "Unknown chunking method '#{@profile.method}'" unless CHUNKING_METHODS[@profile.method]
+    raise UnknownChunkingMethod, "Unknown chunking method '#{chunking_method}'" unless CHUNKING_METHODS[chunking_method]
 
     begin
-      @parser.send(CHUNKING_METHODS[@profile.method], @profile)
+      @parser.send(CHUNKING_METHODS[chunking_method])
     rescue NoMethodError
       raise UnsupportedChunkingMethod,
-              "Parser (#{@parser.class.name}) doesn't support chunking method '#{@profile.method}'"
+              "Parser (#{@parser.class.name}) doesn't support chunking method '#{chunking_method}'"
     end
+  end
+
+  private
+
+  def chunking_method
+    @parser.profile.method
   end
 end

--- a/app/services/chonker.rb
+++ b/app/services/chonker.rb
@@ -27,6 +27,6 @@ class Chonker
   private
 
   def chunking_method
-    @parser.profile.method
+    @parser.chunking_profile.method
   end
 end

--- a/app/services/parsers.rb
+++ b/app/services/parsers.rb
@@ -1,9 +1,4 @@
 module Parsers
-
-  # A parser can include this to indicate it can do its own chunking, implementing
-  # `#chunk_METHOD(profile) for supported chunking methods, with at least `bytes` method. `
-  module SelfChunker; end
-
   def self.parser_for(filename)
     name_locase = filename.downcase
     return Parsers::Pdf if name_locase.end_with?(".pdf")

--- a/app/services/parsers.rb
+++ b/app/services/parsers.rb
@@ -1,5 +1,9 @@
 module Parsers
 
+  # A parser can include this to indicate it can do its own chunking, implementing
+  # `#chunk_METHOD(profile) for supported chunking methods, with at least `bytes` method. `
+  module SelfChunker; end
+
   def self.parser_for(filename)
     name_locase = filename.downcase
     return Parsers::Pdf if name_locase.end_with?(".pdf")

--- a/app/services/parsers/basic_text_chunker.rb
+++ b/app/services/parsers/basic_text_chunker.rb
@@ -1,23 +1,20 @@
 module Parsers
   module BasicTextChunker
     def chunk_by_bytes
-      chunk_size = profile.size
+      chunk_size = chunking_profile.size
 
       chunks = text.gsub(/  +/, "  ").gsub(/\n\n+/, "\n\n").scan(/.{0,#{chunk_size}}\b /m)
 
       overlapped_chunks(chunks)
     end
 
-    def document
-      @document
-    end
-
-    def profile
-      document.chunking_profile
+    # The chunking profile used by the parser, based on the document it is parsing
+    def chunking_profile
+      @document.chunking_profile
     end
 
     def overlapped_chunks(chunks)
-      chunk_overlap = profile.overlap
+      chunk_overlap = chunking_profile.overlap
       overlapped_chunks = []
 
       chunks.each_with_index do |chunk, idx|

--- a/app/services/parsers/basic_text_chunker.rb
+++ b/app/services/parsers/basic_text_chunker.rb
@@ -1,0 +1,40 @@
+module Parsers
+  module BasicTextChunker
+    include SelfChunker
+
+    def chunk_by_bytes(profile)
+      chunk_size = profile.size
+
+      chunks = text.gsub(/  +/, "  ").gsub(/\n\n+/, "\n\n").scan(/.{0,#{chunk_size}}\b /m)
+
+      overlapped_chunks(chunks, profile)
+    end
+
+    private
+
+    def overlapped_chunks(chunks, profile)
+      chunk_overlap = profile.overlap
+      overlapped_chunks = []
+
+      chunks.each_with_index do |chunk, idx|
+        prev_chunk = chunks[idx - 1] if idx.positive?
+        next_chunk = chunks[idx + 1] if idx < (chunks.length - 1)
+
+        # TODO: this is horribly inefficient - stop copying so much string data around
+        if prev_chunk
+          ending_of_prev_chunk = prev_chunk.match(/\b(.{1,#{chunk_overlap}})\Z/m)
+          chunk = "#{ending_of_prev_chunk[1] if ending_of_prev_chunk}#{chunk}"
+        end
+
+        if next_chunk
+          beginning_of_next_chunk = next_chunk.match(/^(.{1,#{chunk_overlap}})\b/)
+          chunk = "#{chunk}#{beginning_of_next_chunk[1] if beginning_of_next_chunk}"
+        end
+
+        overlapped_chunks << chunk
+      end
+
+      overlapped_chunks
+    end
+  end
+end

--- a/app/services/parsers/basic_text_chunker.rb
+++ b/app/services/parsers/basic_text_chunker.rb
@@ -1,7 +1,5 @@
 module Parsers
   module BasicTextChunker
-    include SelfChunker
-
     def chunk_by_bytes(profile)
       chunk_size = profile.size
 

--- a/app/services/parsers/basic_text_chunker.rb
+++ b/app/services/parsers/basic_text_chunker.rb
@@ -1,16 +1,22 @@
 module Parsers
   module BasicTextChunker
-    def chunk_by_bytes(profile)
+    def chunk_by_bytes
       chunk_size = profile.size
 
       chunks = text.gsub(/  +/, "  ").gsub(/\n\n+/, "\n\n").scan(/.{0,#{chunk_size}}\b /m)
 
-      overlapped_chunks(chunks, profile)
+      overlapped_chunks(chunks)
     end
 
-    private
+    def document
+      @document
+    end
 
-    def overlapped_chunks(chunks, profile)
+    def profile
+      document.chunking_profile
+    end
+
+    def overlapped_chunks(chunks)
       chunk_overlap = profile.overlap
       overlapped_chunks = []
 

--- a/app/services/parsers/pdf.rb
+++ b/app/services/parsers/pdf.rb
@@ -1,5 +1,7 @@
 module Parsers
   class Pdf
+    include BasicTextChunker
+
     def initialize(document)
       @document = document
     end

--- a/app/services/parsers/text.rb
+++ b/app/services/parsers/text.rb
@@ -1,5 +1,7 @@
 module Parsers
   class Text
+    include BasicTextChunker
+
     def initialize(document)
       @document = document
     end
@@ -7,6 +9,5 @@ module Parsers
     def text
       @text ||= @document.contents
     end
-
   end
 end

--- a/app/services/the_ingestor.rb
+++ b/app/services/the_ingestor.rb
@@ -48,7 +48,7 @@ class TheIngestor
   end
 
   def chonker
-    @chonker ||= Chonker.new(parser, @document.chunking_profile)
+    @chonker ||= Chonker.new(parser)
   end
 
   def embedder


### PR DESCRIPTION
We're moving chunking to the parsers.

- Implemented a `Parsers::BasicTextChunker` module that provides `chunk_bytes`
- Note the passing of `profile` as parameter rather than initializing parser with profile
- `Chonker` no longer does any chunking
- `Chonker` expects parsers to support `chunk_by_xxx` method for supported chunking methods `xxx`
- `Pdf` and `Text` parsers include `BasicTextChunker`, preserving the prior chunking approach. 
- Using chunking profile from within document instead of passing it to parser
