### PR TITLE
Change API to allow ingest by iterating over chunks

### DIFF
--- a/app/services/chonker.rb
+++ b/app/services/chonker.rb
@@ -13,6 +13,17 @@ class Chonker
     @parser = parser
   end
 
+  # Yield each chunk
+  def each(&block)
+    if block_given?
+      chunks.each(&block)
+    else
+      chunks.each
+    end
+  end
+
+  private
+
   def chunks
     raise UnknownChunkingMethod, "Unknown chunking method '#{chunking_method}'" unless CHUNKING_METHODS[chunking_method]
 
@@ -23,8 +34,6 @@ class Chonker
               "Parser (#{@parser.class.name}) doesn't support chunking method '#{chunking_method}'"
     end
   end
-
-  private
 
   def chunking_method
     @parser.chunking_profile.method

--- a/app/services/chonker.rb
+++ b/app/services/chonker.rb
@@ -13,7 +13,6 @@ class Chonker
     @parser = parser
   end
 
-  # Yield each chunk
   def each(&block)
     if block_given?
       chunks.each(&block)

--- a/app/services/chonker.rb
+++ b/app/services/chonker.rb
@@ -2,6 +2,8 @@ class Chonker
   class UnknownChunkingMethod < StandardError; end
   class UnsupportedChunkingMethod < StandardError; end
 
+  include Enumerable
+
   CHUNKING_METHODS = {
     "bytes" => :chunk_by_bytes,
     "sentences" => :chunk_by_sentences,

--- a/app/services/the_ingestor.rb
+++ b/app/services/the_ingestor.rb
@@ -8,8 +8,7 @@ class TheIngestor
     ensure_collection_exists
 
     @document.chunking!
-    index = 0
-    chonker.each do |c|
+    chonker.each_with_index do |c, index|
       if index.zero?
         # Temporary hack since parser is still a brute force chunker right now.
         @document.chunked!
@@ -23,10 +22,8 @@ class TheIngestor
       embedding = embedder.embed(chunk.content)
       ids = chromadb.add_documents(@collection_id, [chunk.content], [embedding])
       chunk.update!(vector_id: ids.first)
-
-      index += 1
     end
-    Rails.logger.info("Got #{index} chunks from #{@document.filename}.")
+    Rails.logger.info("Got chunks from #{@document.filename}.")
 
     @document.embedded!
   rescue StandardError => e


### PR DESCRIPTION

The goal is to iterate over chunks and embed them.

- `Chonker#each` can take a block to yield chunks (or returns iterator when called without a block)
- `TheIngestor#ingest` modified to iterate through chunks and embed them.

Changes to parsers to actually incrementally yield chunks per parser will come afterwards.