### PR TITLE
Support provisioing of modelConfigs & modelServers:

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -48,8 +48,8 @@ services:
     volumes:
       - archyve_files:/rails/storage
     extra_hosts:
-    - "host.docker.internal:host-gateway"
-    command: bin/rails db:seed && bundle exec sidekiq
+      - "host.docker.internal:host-gateway"
+    command: ['/bin/bash', '-c', 'bin/rails db:seed && bundle exec sidekiq']
     depends_on:
       - redis
       - postgres

--- a/db/migrate/20240509190359_add_provisioning_columns_to_model_tables.rb
+++ b/db/migrate/20240509190359_add_provisioning_columns_to_model_tables.rb
@@ -1,0 +1,9 @@
+class AddProvisioningColumnsToModelTables < ActiveRecord::Migration[7.1]
+  def change
+    add_column :model_configs, :provisioned, :boolean, default: false, if_not_exists: true
+    add_column :model_servers, :provisioned, :boolean, default: false, if_not_exists: true
+
+    add_column :model_configs, :enabled, :boolean, default: true, if_not_exists: true
+    add_column :model_servers, :enabled, :boolean, default: true, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -137,6 +137,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_181405) do
     t.integer "model_server_id", null: false
     t.boolean "embedding", default: false
     t.boolean "default", default: false
+    t.boolean "provisioned", default: false
+    t.boolean "enabled", default: true
     t.index ["model_server_id"], name: "index_model_configs_on_model_server_id"
   end
 
@@ -145,6 +147,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_181405) do
     t.string "url"
     t.integer "provider"
     t.boolean "default"
+    t.boolean "provisioned", default: false
+    t.boolean "enabled", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
- Adds `provisioned` column to both tables.
- Adds `enabled` column to both table.
- If provisioned entities are removed from configuration, said entities are disabled, rather than deleted (_and no longer consider "provisioned"_).
- Fixes a potential `compose` bug where `command:` now expects an excutable expression in the for of an array.