### PR TITLE
Use `pdftotext` to parse PDF files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips netcat-traditional libpq5 && \
+    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips netcat-traditional libpq5 poppler-utils && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/app/services/parsers/pdf.rb
+++ b/app/services/parsers/pdf.rb
@@ -6,34 +6,13 @@ module Parsers
       @document = document
     end
 
-    def pages
-      reader.pages.size
-    end
-
-    def page(index)
-      reader.page(index).text
-    end
-
     def text
-      @text ||= begin
-        text = ""
-        reader.pages.each do |page|
-          text << page.text
-        end
-
-        text
-      end
-    end
-
-    private
-
-    def reader
-      @reader ||= begin
-        io = StringIO.new
-        io.puts(@document.contents)
-
-        PDF::Reader.new(io)
-      end
+      # NOTE: Using -raw opt causes text to be broken up a lot; but not using raw
+      #       may cause tables to be "pretty" in text which may not be ideal for chunking.
+      #       Not specifying works best for rotated pages, so doing that for now
+      cmd = 'pdftotext - -'
+      txt, = Open3.capture2(cmd, stdin_data: @document.contents, binmode: true)
+      txt
     end
   end
 end

--- a/app/services/parsers/pdf.rb
+++ b/app/services/parsers/pdf.rb
@@ -11,8 +11,12 @@ module Parsers
       #       may cause tables to be "pretty" in text which may not be ideal for chunking.
       #       Not specifying works best for rotated pages, so doing that for now
       cmd = 'pdftotext - -'
-      txt, = Open3.capture2(cmd, stdin_data: @document.contents, binmode: true)
-      txt
+      txt, serr, status = Open3.capture3(cmd, stdin_data: @document.contents, binmode: true)
+      return txt if status.success?
+
+      Rails.logger.error("Error running '#{cmd}' on PDF: #{@document.filename}\n#{serr}")
+
+      raise StandardError, "Error converting PDF to text: #{@document.filename}'"
     end
   end
 end

--- a/ops.yml
+++ b/ops.yml
@@ -1,6 +1,7 @@
 dependencies:
   brew:
     - overmind
+    - poppler
   custom:
     - bundle config --local path vendor/bundle
     - bundle config set --local build.pg ${PG_OPTS}


### PR DESCRIPTION
The `pdftotext` tool handles PDFs well, and deals with rotated pages well. 

- Run `ops up` to get it into `brew` or install `poppler` yourself
- The `Dockerfile` installed `poppler-utls` to ensure it gets into the built images