### PR TITLE
Text chunking using recursive text splitting for plain text and markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,3 +101,5 @@ gem "rubocop-rspec", "~> 2.28"
 gem "pagy", "~> 8.0"
 
 gem "motor-admin", "~> 0.4.26"
+
+gem "baran", "~> 0.1.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     audited (5.6.0)
       activerecord (>= 5.2, < 7.2)
       activesupport (>= 5.2, < 7.2)
+    baran (0.1.12)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.6)
@@ -440,6 +441,7 @@ PLATFORMS
 DEPENDENCIES
   aasm (~> 5.5)
   activestorage (~> 7.1)
+  baran (~> 0.1.12)
   bootsnap
   capybara
   debug

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -22,7 +22,7 @@ module DocumentsHelper
 
   def default_chunk_size(method)
     case method
-    when :bytes then 200
+    when :bytes then 1000
     when "sentences" then 5
     when "paragraphs" then 1
     else 1
@@ -31,7 +31,7 @@ module DocumentsHelper
 
   def default_chunk_overlap(method)
     case method
-    when :bytes then 50
+    when :bytes then 200
     when "sentences" then 1
     when "paragraphs" then 0
     when "pages" then 0

--- a/app/services/parsers.rb
+++ b/app/services/parsers.rb
@@ -1,9 +1,11 @@
 module Parsers
   def self.parser_for(filename)
     name_locase = filename.downcase
-    return Parsers::Pdf if name_locase.end_with?(".pdf")
-    return Parsers::Docx if name_locase.end_with?(".docx")
-    return Parsers::Text if name_locase.end_with?(".txt", ".html", ".md")
+
+    return Pdf if name_locase.end_with?(".pdf")
+    return Docx if name_locase.end_with?(".docx")
+    return CommonMark if name_locase.end_with?(".md")
+    return Text if name_locase.end_with?(".txt", ".html")
 
     raise StandardError, "Unsupported file extension: '#{filename.slice(/\.\w+$/)}'"
   end

--- a/app/services/parsers/common_mark.rb
+++ b/app/services/parsers/common_mark.rb
@@ -1,0 +1,35 @@
+module Parsers
+  # Markdown text chunker that uses recursive text splitter, with a separator
+  # specification that uses markdown semantics and considers HTML tables
+  class CommonMark < Text
+    def _chunking_separators
+      [
+        # markdown-specific separators
+        "\n# ", # h1
+        "\n## ", # h2
+        "\n### ", # h3
+        "\n#### ", # h4
+        "\n##### ", # h5
+        "\n###### ", # h6
+        "```\n\n", # code block
+        "\n\n***\n\n", # horizontal rule
+        "\n\n---\n\n", # horizontal rule
+        "\n\n___\n\n", # horizontal rule
+        "\n\n", # new line
+
+        # html table content-related separators
+        "\n<table",
+        "<tr",  # may have attributes
+        "<td>",
+        "<ul>", # html lists (usually within tables)
+        "<ol>",
+        "<li>",
+
+        # plain text
+        "\n", # new line
+        " ", # space
+        "", # empty
+      ]
+    end
+  end
+end

--- a/app/services/parsers/docx.rb
+++ b/app/services/parsers/docx.rb
@@ -11,7 +11,7 @@ module Parsers
 
       Rails.logger.error("Error running '#{cmd}' on DOCX: #{@document.filename}\n#{serr}")
 
-      raise StandardError, "Error converting DPCX to markdown: #{@document.filename}'"
+      raise StandardError, "Error converting DOCX to markdown: #{@document.filename}'"
     end
   end
 end

--- a/app/services/parsers/docx.rb
+++ b/app/services/parsers/docx.rb
@@ -1,22 +1,17 @@
 module Parsers
-  class Docx
-    include BasicTextChunker
-
-    def initialize(document)
-      @document = document
-    end
-
+  # DOCX parser converts word documents into commonmark (with tables) markdown
+  class Docx < CommonMark
     def text
       # NOTE: Using -raw opt causes text to be broken up a lot; but not using raw
       #       may cause tables to be "pretty" in text which may not be ideal for chunking.
       #       Not specifying works best for rotated pages, so doing that for now
-      cmd = 'pandoc -f docx  --to=commonmark -'
+      cmd = 'pandoc -f docx  --wrap=none --to=commonmark -'
       txt, serr, status = Open3.capture3(cmd, stdin_data: @document.contents, binmode: true)
       return txt if status.success?
 
       Rails.logger.error("Error running '#{cmd}' on DOCX: #{@document.filename}\n#{serr}")
 
-      raise StandardError, "Error converting DPCX to text: #{@document.filename}'"
+      raise StandardError, "Error converting DPCX to markdown: #{@document.filename}'"
     end
   end
 end

--- a/app/services/parsers/recursive_text_chunker.rb
+++ b/app/services/parsers/recursive_text_chunker.rb
@@ -1,0 +1,34 @@
+require 'baran'
+
+module Parsers
+  # Chunker splits text by recursively look at characters.
+  # Recursively tries to split by different characters to find one that works.
+  module RecursiveTextChunker
+    def chunk_by_bytes
+      chunk_size = chunking_profile.size
+      chunk_overlap = chunking_profile.overlap
+      splitter = Baran::RecursiveCharacterTextSplitter.new chunk_size:,
+                                                           chunk_overlap:,
+                                                           separators: chunking_separators
+
+      splitter.chunks(text).map do |c|
+        c[:text]
+      end
+    end
+
+    # The chunking profile used by the parser, based on the document it is parsing
+    def chunking_profile
+      @document.chunking_profile
+    end
+
+    # Override this to return alternate separators; the default is good for plain text.
+    def chunking_separators
+      [
+        "\n\n", # new line
+        "\n", # new line
+        " ", # space
+        "", # empty
+      ]
+    end
+  end
+end

--- a/app/services/parsers/text.rb
+++ b/app/services/parsers/text.rb
@@ -1,6 +1,7 @@
 module Parsers
+  # Plain text chunker that uses recursive text splitter
   class Text
-    include BasicTextChunker
+    include RecursiveTextChunker
 
     def initialize(document)
       @document = document


### PR DESCRIPTION

- Use the `baran` gem which implements character splitters based on Langchain's text splitters
- Define a recursive text splitting chunker with customizable separator rules
- Modify `Text` parser to use recursive text splitting
- Define `CommonMark` parser derived from `Text` with custom separator rules to account for markdown and embedded HTML tables
- Modify `Docx` parser to subclass `CommonMark` and tweak pandoc invocation to not word-wrap long lines.
- Modify `Parsers#parser_for` to select `CommonMark` parser for `.md` files
- Modify the default chunking size/overlap to bigger defaults of 1000 and 200 characters respectively, which yield better chunks, especially with the new text splitter
