### PR TITLE
Return parsed chunks as ChunkRecords

### DIFF
--- a/app/services/chonker.rb
+++ b/app/services/chonker.rb
@@ -4,6 +4,7 @@ class Chonker
 
   include Enumerable
 
+  # Each chunking method returns an array of ChunkRecords
   CHUNKING_METHODS = {
     "bytes" => :chunk_by_bytes,
     "sentences" => :chunk_by_sentences,

--- a/app/services/parsers/basic_text_chunker.rb
+++ b/app/services/parsers/basic_text_chunker.rb
@@ -32,7 +32,7 @@ module Parsers
           chunk = "#{chunk}#{beginning_of_next_chunk[1] if beginning_of_next_chunk}"
         end
 
-        overlapped_chunks << chunk
+        overlapped_chunks << ChunkRecord.new(content: chunk)
       end
 
       overlapped_chunks

--- a/app/services/parsers/chunk_record.rb
+++ b/app/services/parsers/chunk_record.rb
@@ -1,0 +1,19 @@
+module Parsers
+  # A chunk record has the content and its key, where the `key` is used to generate the
+  # embedding. If a chunk record is created without a key, the content is used as the key.
+  class ChunkRecord
+    attr_reader :content
+
+    def initialize(content:, key: nil)
+      raise StandardError, "Content required" if content.nil? || content.blank?
+
+      @content = content
+      @key = key
+    end
+
+    def key
+      # Use content as the key for embedding if no separate key specified
+      @key || content
+    end
+  end
+end

--- a/app/services/parsers/chunk_record.rb
+++ b/app/services/parsers/chunk_record.rb
@@ -1,17 +1,18 @@
 module Parsers
-  # A chunk record has the content and its key, where the `key` is used to generate the
-  # embedding. If a chunk record is created without a key, the content is used as the key.
+  # A chunk record has the content and its "embedding content" which is used to generate the
+  # embedding. If a chunk record is created without a separately specific `embedding_content`,
+  # the `content`` is used instead.
   class ChunkRecord
     attr_reader :content
 
-    def initialize(content:, key: nil)
+    def initialize(content:, embedding_content: nil)
       @content = content
-      @key = key
+      @embedding_content = embedding_content
     end
 
-    def key
+    def embedding_content
       # Use content as the key for embedding if no separate key specified
-      @key || content
+      @embedding_content || content
     end
   end
 end

--- a/app/services/parsers/chunk_record.rb
+++ b/app/services/parsers/chunk_record.rb
@@ -5,8 +5,6 @@ module Parsers
     attr_reader :content
 
     def initialize(content:, key: nil)
-      raise StandardError, "Content required" if content.nil? || content.blank?
-
       @content = content
       @key = key
     end

--- a/app/services/parsers/recursive_text_chunker.rb
+++ b/app/services/parsers/recursive_text_chunker.rb
@@ -12,7 +12,7 @@ module Parsers
                                                            separators: chunking_separators
 
       splitter.chunks(text).map do |c|
-        c[:text]
+        ChunkRecord.new(content: c[:text])
       end
     end
 

--- a/app/services/the_ingestor.rb
+++ b/app/services/the_ingestor.rb
@@ -8,18 +8,19 @@ class TheIngestor
     ensure_collection_exists
 
     @document.chunking!
-    chonker.each_with_index do |c, index|
+    chonker.each_with_index do |crec, index|
       if index.zero?
         # Temporary hack since parser is still a brute force chunker right now.
         @document.chunked!
         @document.embedding!
       end
 
-      chunk = Chunk.new(document: @document, content: c)
+      chunk = Chunk.new(document: @document, content: crec.content)
       chunk.save!
 
       Rails.logger.info("Embedding chunk #{chunk.id} (#{index})")
-      embedding = embedder.embed(chunk.content)
+      embedding = embedder.embed(crec.key)
+
       ids = chromadb.add_documents(@collection_id, [chunk.content], [embedding])
       chunk.update!(vector_id: ids.first)
     end

--- a/app/services/the_ingestor.rb
+++ b/app/services/the_ingestor.rb
@@ -8,18 +8,18 @@ class TheIngestor
     ensure_collection_exists
 
     @document.chunking!
-    chonker.each_with_index do |crec, index|
+    chonker.each_with_index do |chunk_record, index|
       if index.zero?
         # Temporary hack since parser is still a brute force chunker right now.
         @document.chunked!
         @document.embedding!
       end
 
-      chunk = Chunk.new(document: @document, content: crec.content)
+      chunk = Chunk.new(document: @document, content: chunk_record.content)
       chunk.save!
 
       Rails.logger.info("Embedding chunk #{chunk.id} (#{index})")
-      embedding = embedder.embed(crec.key)
+      embedding = embedder.embed(chunk_record.key)
 
       ids = chromadb.add_documents(@collection_id, [chunk.content], [embedding])
       chunk.update!(vector_id: ids.first)

--- a/app/services/the_ingestor.rb
+++ b/app/services/the_ingestor.rb
@@ -19,7 +19,7 @@ class TheIngestor
       chunk.save!
 
       Rails.logger.info("Embedding chunk #{chunk.id} (#{index})")
-      embedding = embedder.embed(chunk_record.key)
+      embedding = embedder.embed(chunk_record.embedding_content)
 
       ids = chromadb.add_documents(@collection_id, [chunk.content], [embedding])
       chunk.update!(vector_id: ids.first)


### PR DESCRIPTION
- Added `Parser::ChunkRecord` which holds two properties: `content` and `key`. 
  - When creating instances, key is optional
  - Records without a key return content as the key
- Modified the two chunkers to return arrays of `ChunkRecord` instead of just the content strings
- Tweaked `TheIngestor` to handle `ChunkRecord` by
  - creating embedding using `#key` from the record
  - storing the `#content` for insertion into the context for user questions

This sets us for exploring future chunking methods where the key (and therefore embedding) has more information than the associated "content". No functional change to current chunkers.