### PR TITLE
[PATCH] ensure only support column names are passed during provisioning

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -97,16 +97,20 @@ provisioned_model_config_names = provisioned_model_configs.map { |mc| mc["name"]
 ModelConfig.where(provisioned: true).where.not(name: provisioned_model_config_names).update(available: false, provisioned: false)
 ModelServer.where(provisioned: true).where.not(name: provisioned_model_servers_names).update(available: false, provisioned: false)
 
+model_server_fields = ModelServer.column_names
 provisioned_model_servers.each do |fields|
-  puts "provisioning model server for `#{fields["name"]}` ..."
+  fields.slice!(*model_server_fields)
+  puts "provisioning model server for `#{fields}` ..."
 
   ModelServer.find_or_initialize_by(name: fields["name"]).update!(**fields, provisioned: true)
 end
 
 ModelServer.last.make_active if ModelServer.active_server.nil?
 
+model_config_fields = ModelConfig.column_names
 provisioned_model_configs.each do |fields|
-  puts "provisioning model configuration for `#{fields["name"]}` ..."
+  fields.slice!(*model_config_fields)
+  puts "provisioning model configuration for `#{fields}` ..."
 
   ModelConfig.find_or_initialize_by(name: fields["name"]).update!(**fields, provisioned: true)
 end


### PR DESCRIPTION
The idea is to grab the column names from the respective schema, and filter out the keys of any JSON record parsed from provisioner environment variable values (_say **that** 10 times fast_) that do not correspond to a column in said schema.