### PR TITLE
Fix clipboard to use @stimulus-components/clipboard

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,6 @@ eagerLoadControllersFrom("controllers", application)
 // import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
 // lazyLoadControllersFrom("controllers", application)
 
-import Clipboard from "stimulus-clipboard"
+import Clipboard from '@stimulus-components/clipboard'
+
 application.register('clipboard', Clipboard)

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,4 +9,4 @@ pin "trix"
 pin "@rails/actiontext", to: "actiontext.esm.js"
 pin "marked", to: "https://ga.jspm.io/npm:marked@12.0.0/lib/marked.esm.js"
 pin "highlight.js", to: "https://ga.jspm.io/npm:highlight.js@11.9.0/es/index.js"
-pin "stimulus-clipboard" # @4.0.1
+pin "@stimulus-components/clipboard", to: "@stimulus-components--clipboard.js" # @5.0.0

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,3 +9,4 @@ pin "trix"
 pin "@rails/actiontext", to: "actiontext.esm.js"
 pin "marked", to: "https://ga.jspm.io/npm:marked@12.0.0/lib/marked.esm.js"
 pin "highlight.js", to: "https://ga.jspm.io/npm:highlight.js@11.9.0/es/index.js"
+pin "@stimulus-components/clipboard", to: "@stimulus-components--clipboard.js" # @5.0.0

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,4 +9,3 @@ pin "trix"
 pin "@rails/actiontext", to: "actiontext.esm.js"
 pin "marked", to: "https://ga.jspm.io/npm:marked@12.0.0/lib/marked.esm.js"
 pin "highlight.js", to: "https://ga.jspm.io/npm:highlight.js@11.9.0/es/index.js"
-pin "@stimulus-components/clipboard", to: "@stimulus-components--clipboard.js" # @5.0.0

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
+    "@stimulus-components/clipboard": "^5.0.0",
     "highlight.js": "^11.9.0",
     "marked": "^12.0.1",
-    "stimulus-clipboard": "^4.0.1",
     "tailwind-highlightjs": "^2.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@stimulus-components/clipboard@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-components/clipboard/-/clipboard-5.0.0.tgz#1d119c4ba8827c6c11c2e1b9214d0de79bc0cc87"
+  integrity sha512-gbwU1sVBiKfMGGCt6oyXx9mGD+cEcHBSqaz//5UVepoQqzl2jYEUWQGFIO0f48LMOamEQwR1azQKfHq6llv6oA==
+
 app-root-path@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.1.0.tgz#5971a2fc12ba170369a7a1ef018c71e6e47c2e86"
@@ -88,11 +93,6 @@ source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-stimulus-clipboard@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/stimulus-clipboard/-/stimulus-clipboard-4.0.1.tgz#acc9212b479fedc633ecdec8f191a28c1d826a6b"
-  integrity sha512-dem+ihC3Q8+gbyGINdd+dK+9d5vUTnOwoH+n3KcDJvbxrFcq9lV8mWjyhEaDquGxYy3MmqSdz9FHQbG88TBqGg==
 
 sync-fetch@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
Replaced the deprecated strimulus clipboard with the one in stimulus components. This fixes the JS error that was causing turbo streams etc to fail.