### PR TITLE
Add require open3 gem to avoid error

### DIFF
--- a/app/services/parsers/docx.rb
+++ b/app/services/parsers/docx.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Parsers
   # DOCX parser converts word documents into commonmark (with tables) markdown
   class Docx < CommonMark

--- a/app/services/parsers/pdf.rb
+++ b/app/services/parsers/pdf.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Parsers
   class Pdf < Text
     def text


### PR DESCRIPTION
I reproduced the error in a few different versions of ruby 3, and this fixed it.
Fixes #81 