### PR TITLE
Add default conversation source

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,7 +6,7 @@ class Conversation < ApplicationRecord
   has_many :collections, through: :conversation_collections, dependent: :destroy
   has_many :api_calls, as: :traceable, dependent: :destroy
 
-  attribute :source, :integer
+  attribute :source, :integer, default: 0
   enum source: {
     chat: 0,
     api: 1,


### PR DESCRIPTION
Avoid form error caused if someone creates a new conversation without any content.  Otherwise, subsequently clicking on the empty coversation causes the form to blow up on NilClass error.