### PR TITLE
Display title for scraped page

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -7,11 +7,7 @@ module DocumentsHelper
   end
 
   def title_for(document)
-    if document.title.presence
-      document.title
-    else
-      document.filename
-    end
+    document.title || document.filename
   end
 
   def chunks_completed_label_for(total_chunks, completed_chunks, label_name)

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -7,7 +7,11 @@ module DocumentsHelper
   end
 
   def title_for(document)
-    document.title || document.filename
+    if document.link.blank?
+      document.filename
+    else
+      document.title || document.filename
+    end
   end
 
   def chunks_completed_label_for(total_chunks, completed_chunks, label_name)

--- a/app/services/chunk_document.rb
+++ b/app/services/chunk_document.rb
@@ -14,6 +14,8 @@ class ChunkDocument
       EmbedChunkJob.perform_async(chunk.id)
     end
 
+    @document.update(title: parser.get_title)
+
     @document.chunked!
   end
 

--- a/app/services/parsers/html.rb
+++ b/app/services/parsers/html.rb
@@ -1,5 +1,9 @@
 module Parsers
   class Html < Text
+    def get_title
+      Nokogiri::HTML(@document.text).css('title').text
+    end
+
     private
 
     def text_type

--- a/app/services/parsers/html.rb
+++ b/app/services/parsers/html.rb
@@ -1,7 +1,7 @@
 module Parsers
   class Html < Text
     def get_title
-      Nokogiri::HTML(@document.text).css('title').text
+      Nokogiri::HTML(@document.contents).css('title').text
     end
 
     private

--- a/app/services/parsers/text.rb
+++ b/app/services/parsers/text.rb
@@ -17,6 +17,11 @@ module Parsers
       @text ||= @document.contents
     end
 
+    # Overriede to set approriate title
+    def get_title
+      ''
+    end
+
     private
 
     def text_type

--- a/app/views/shared/_document.html.erb
+++ b/app/views/shared/_document.html.erb
@@ -6,7 +6,7 @@
       <div class="flex-1">
         <div class="flex items-baseline">
           <div class="pb-4 mr-2">
-            <%= link_to document.filename, collection_document_path(document.collection, document), format: :turbo_stream %>
+            <%= link_to title_for(document), collection_document_path(document.collection, document), format: :turbo_stream %>
           </div>
           <%= render "shared/document_state_badges", document: %>
         </div>


### PR DESCRIPTION
I meant to include this in last PR.  Displays title tag for pages scraped from a URL but not uploaded files, since that seemed confusing.