### PR TITLE
Add context window length property to model config

### DIFF
--- a/app/models/model_config.rb
+++ b/app/models/model_config.rb
@@ -15,6 +15,10 @@ class ModelConfig < ApplicationRecord
     model_server&.api_version_required?
   end
 
+  def context_window_size
+    self[:context_window_size] || model_server.default_context_window_size
+  end
+
   def make_active_embedding_model
     raise ModelTypeError, "Model is not an embedding model" unless embedding?
 

--- a/app/models/model_server.rb
+++ b/app/models/model_server.rb
@@ -30,6 +30,19 @@ class ModelServer < ApplicationRecord
     end
   end
 
+  def default_context_window_size
+    if provider_openai_azure?
+      # May be more per model, but we can assume a bigger default
+      8 * 1024
+    elsif provider_openai?
+      # May be more per model, but we can assume a bigger default
+      16 * 1024
+    else
+      # The default for ollama unless overridden by custom Modelfile
+      2 * 1024
+    end
+  end
+
   def make_active
     active_servers = ModelServer.active
     return if active_servers.length == 1 && active_servers.first == self

--- a/db/migrate/20241002185332_add_context_window_size_to_model_config.rb
+++ b/db/migrate/20241002185332_add_context_window_size_to_model_config.rb
@@ -1,0 +1,5 @@
+class AddContextWindowSizeToModelConfig < ActiveRecord::Migration[7.1]
+  def change
+    add_column :model_configs, :context_window_size, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_29_193319) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_02_185332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -226,6 +226,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_29_193319) do
     t.bigint "model_server_id"
     t.float "distance_min"
     t.float "distance_max"
+    t.integer "context_window_size"
     t.index ["model_server_id"], name: "index_model_configs_on_model_server_id"
   end
 

--- a/spec/factories/model_configs.rb
+++ b/spec/factories/model_configs.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     provisioned { false }
     available { true }
     model_server { nil }
+    context_window_size { nil }
   end
 end

--- a/spec/models/model_config_spec.rb
+++ b/spec/models/model_config_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ModelConfig do
+  subject { create(:model_config, name: model_name, model:, model_server:, embedding:, context_window_size:) }
+
+  let(:model_server) { create(:model_server, provider: "ollama", url: 'http://localhost:11434', active: false) }
+  let(:model_name) { "Nomic" }
+  let(:model) { "nomic-embed-text" }
+  let(:embedding) { true }
+  let(:context_window_size) { nil }
+
+  describe "#context_window_size" do
+    context "when nil in model config" do
+      it "returns default from model server" do
+        expect(subject.context_window_size).to eq(model_server.default_context_window_size)
+      end
+    end
+
+    context "when set in model config" do
+      let(:context_window_size) { 12345 }
+
+      it "returns correct value" do
+        expect(subject.context_window_size).to eq(12345)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A small step towards some future work where knowing the context window size will be needed to be able to use AI to help with some chunk processing.