### PR TITLE
Fix HTML parsing / chunking by using markdown conversion (for now)

### DIFF
--- a/app/services/parsers.rb
+++ b/app/services/parsers.rb
@@ -8,8 +8,7 @@ module Parsers
     return Docx if name_locase.end_with?(".docx")
     return CommonMark if name_locase.end_with?(".md")
     return Text if name_locase.end_with?(".txt")
-    return Html if name_locase.ends_with?(".html")
-    return Html if name_locase.match?(/.html*\z/)
+    return HtmlViaMarkdown if name_locase.match?(/\.?html*\z/)
 
     raise UnsupportedFileFormat, "Unsupported file extension: '#{filename.slice(/\.\w+$/)}'"
   end

--- a/app/services/parsers/docx.rb
+++ b/app/services/parsers/docx.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parsers
   # DOCX parser converts word documents into commonmark (with tables) markdown
   class Docx < CommonMark

--- a/app/services/parsers/docx.rb
+++ b/app/services/parsers/docx.rb
@@ -11,11 +11,15 @@ module Parsers
       #       may cause tables to be "pretty" in text which may not be ideal for chunking.
       #       Not specifying works best for rotated pages, so doing that for now
       @text, e, s = Open3.capture3(CMD, stdin_data: @document.contents, binmode: true)
-      return if s.success?
+      raise_error(e) unless s.success?
+    end
 
-      error = e&.lines&.first || 'Unknown error running pandoc'
-      Rails.logger.error("Error running '#{CMD}' on DOCX: #{@document.filename}\n#{error}")
-      raise StandardError, "Error converting DOCX to markdown: #{@document.filename}: #{error}"
+    private
+
+    def raise_error(error_output)
+      error = error_output&.lines&.first || 'Unknown error running pandoc'
+      Rails.logger.error("Error running '#{CMD}' on DOCX: #{filename}\n#{error}")
+      raise StandardError, "Error converting DOCX to markdown: #{filename}: #{error}"
     end
   end
 end

--- a/app/services/parsers/docx.rb
+++ b/app/services/parsers/docx.rb
@@ -1,18 +1,19 @@
 module Parsers
   # DOCX parser converts word documents into commonmark (with tables) markdown
   class Docx < CommonMark
+    CMD = 'pandoc -f docx  --wrap=none --to=commonmark -'
+
     def initialize(document)
       super(document)
       # NOTE: Using -raw opt causes text to be broken up a lot; but not using raw
       #       may cause tables to be "pretty" in text which may not be ideal for chunking.
       #       Not specifying works best for rotated pages, so doing that for now
-      cmd = 'pandoc -f docx  --wrap=none --to=commonmark -'
-      @text, serr, status = Open3.capture3(cmd, stdin_data: @document.contents, binmode: true)
-      return if status.success?
+      @text, e, s = Open3.capture3(CMD, stdin_data: @document.contents, binmode: true)
+      return if s.success?
 
-      Rails.logger.error("Error running '#{cmd}' on DOCX: #{@document.filename}\n#{serr}")
-
-      raise StandardError, "Error converting DOCX to markdown: #{@document.filename}'"
+      error = e&.lines&.first || 'Unknown error running pandoc'
+      Rails.logger.error("Error running '#{CMD}' on DOCX: #{@document.filename}\n#{error}")
+      raise StandardError, "Error converting DOCX to markdown: #{@document.filename}: #{error}"
     end
   end
 end

--- a/app/services/parsers/html_via_markdown.rb
+++ b/app/services/parsers/html_via_markdown.rb
@@ -23,8 +23,8 @@ module Parsers
         @text = r[(r.index(ENDFRONTMATTER) + ENDFRONTMATTER.length)..]
       else
         error = e&.lines&.first || 'Unknown error running pandoc'
-        Rails.logger.error("Error running '#{cmd}' on HTML: #{@document.filename}\n#{error}")
-        raise StandardError, "Error converting HTML to MD: #{@document.filename}: #{error}'"
+        Rails.logger.error("Error running '#{CMD}' on HTML: #{@document.filename}\n#{error}")
+        raise StandardError, "Error converting HTML to MD: #{@document.filename}: #{error}"
       end
     end
 

--- a/app/services/parsers/html_via_markdown.rb
+++ b/app/services/parsers/html_via_markdown.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Parsers
+  # HTML parser converts HTML documents into commonmark (with tables) markdown
+  class HtmlViaMarkdown < CommonMark
+    CMD = <<~TEXT
+      pandoc -s -f html --strip-comments --to=markdown-raw_attribute - | grep -v "^:" |\
+      grep -v '^```' |\
+      grep -v '<!-- -->' |\
+      sed -e ':again' -e N -e '$!b again' -e 's/{[^}]*}//g'
+    TEXT
+
+    ENDFRONTMATTER = "---\n\n"
+
+    def initialize(document)
+      super(document)
+      # Convert the HTML into markdown, strip out all the junk we don't need
+      rawtxt, serr, status = Open3.capture3(CMD, stdin_data: @document.contents, binmode: true)
+      if status.success?
+        # extract the front matter from the raw text
+        @title = rawtxt.match(/title: (.+)\n/).captures.join
+        # remove the front matter to get the body
+        @text = rawtxt[(rawtxt.index("---\n\n") + 5)..]
+      else
+        Rails.logger.error("Error running '#{cmd}' on HTML: #{@document.filename}\n#{serr}")
+        raise StandardError, "Error converting HTML to markdown: #{@document.filename}'"
+      end
+    end
+
+    def title
+      @title || super
+    end
+  end
+end

--- a/app/services/parsers/text.rb
+++ b/app/services/parsers/text.rb
@@ -22,6 +22,10 @@ module Parsers
       ''
     end
 
+    def filename
+      @document.filename
+    end
+
     private
 
     def text_type

--- a/spec/services/parsers_spec.rb
+++ b/spec/services/parsers_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe Parsers do
     include_examples "supported_format_parser", ".docx", Parsers::Docx
     include_examples "supported_format_parser", ".md", Parsers::CommonMark
     include_examples "supported_format_parser", ".txt", Parsers::Text
-    include_examples "supported_format_parser", ".html", Parsers::Html
+    include_examples "supported_format_parser", ".html", Parsers::HtmlViaMarkdown
   end
 end


### PR DESCRIPTION

As a quick fix, I'm using `pandoc` to convert HTML to markdown for chunking.