### PR TITLE
Add xml context and logic to augmented prompt

### DIFF
--- a/spec/factories/chunks.rb
+++ b/spec/factories/chunks.rb
@@ -5,4 +5,11 @@ FactoryBot.define do
     content { Faker::Lorem.sentence(word_count: 10) }
     embedding_content { Faker::Lorem.sentence(word_count: 16) }
   end
+
+  factory :chunk_from_web, class: 'Chunk' do
+    document { association(:document_from_web) }
+    vector_id { SecureRandom.uuid }
+    content { Faker::Lorem.sentence(word_count: 10) }
+    embedding_content { Faker::Lorem.sentence(word_count: 16) }
+  end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,13 +3,29 @@ FactoryBot.define do
     chunks { [] }
     user { association(:user) }
     collection { association(:collection) }
-    filename { "gnu_manifesto.md" }
-    state { :chunked }
+    state { :created }
     vector_id { nil } # TODO: we probably don't need this
     chunking_profile { association(:chunking_profile) }
 
+    filename { "gnu_manifesto.md" }
+
     trait :with_file do
-      file { Rails.root.join("spec/fixtures/files/small_doc.md") }
+      file { Rails.root.join("spec/fixtures/files/gnu_manifesto.md") }
+    end
+  end
+  factory :document_from_web, class: 'Document' do
+    chunks { [] }
+    user { association(:user) }
+    collection { association(:collection) }
+    state { :created }
+    vector_id { nil } # TODO: we probably don't need this
+    chunking_profile { association(:chunking_profile) }
+
+    filename { "web-123.html" }
+    link { Faker::Internet.url }
+
+    trait :with_file do
+      file { Rails.root.join("spec/fixtures/files/small_page.html") }
     end
   end
 end

--- a/spec/services/prompt_augmentor_spec.rb
+++ b/spec/services/prompt_augmentor_spec.rb
@@ -3,45 +3,65 @@ RSpec.describe PromptAugmentor do
 
   let(:message) { create(:message, content: "What tool should I use to install Ruby?", conversation:) }
   let(:conversation) { create(:conversation, messages: []) }
-  let(:chunks) { create_list(:chunk, 2) }
+
+  let(:chunks) do
+    [
+      create(:chunk),
+      create(:chunk_from_web),
+    ]
+  end
+  let(:graph_entity) { create(:graph_entity, summary: "The Ruby programming language.") }
   let(:search_hits) do
     [
       Search::SearchHit.new(chunks[0], 200.0),
       Search::SearchHit.new(chunks[1], 220.0),
+      Search::SearchHit.new(graph_entity, 240.0),
     ]
   end
 
   describe "#prompt" do
     it "has the correct content" do
-      expect(subject.prompt).to eq(
-        <<~PROMPT
-          Here is some context that may help you answer the following question:
+      content = <<~CONTENT
+        You are given a query to answer based on some given textual context, all inside xml tags.
+        If the answer is not in the context but you think you know the answer, explain that to the user then answer with your own knowledge.
 
-          #{chunks.first.content}
+        <context>
+        <context_item name="#{search_hits.first.name}">
+        <filename>#{chunks.first.document.filename}</filename>
+        <text>#{chunks.first.content}</text>
+        </context_item>
+        <context_item name="#{search_hits.second.name}">
+        <url>#{chunks.second.document.link}</url>
+        <scraped>#{chunks.second.document.created_at}</scraped>
+        <text>#{chunks.second.content}</text>
+        </context_item>
+        <context_item name="#{search_hits.third.name}">
+        <text>#{graph_entity.summary}</text>
+        </context_item>
+        </context>
 
-          #{chunks.second.content}
+        Query: #{message.content}
+      CONTENT
 
-          Question: What tool should I use to install Ruby?
-        PROMPT
-      )
+      expect(subject.prompt).to eq(content)
     end
 
     context "when no search_hits are given" do
       let(:search_hits) { [] }
 
-      it "returns just the original prompt" do
-        expect(subject.prompt).to eq(message.content)
+      it "returns nil to indicate to ui no augmentation was done" do
+        expect(subject.prompt).to be_nil
       end
     end
   end
 
   describe "#augment" do
     it "updates the message with the augmented prompt" do
-      expect { subject.augment }.to change { message.reload.prompt }.from(nil).to(/Here is some context/)
+      expect { subject.augment }.to change { message.reload.prompt }.from(nil).to(/You are given a query/)
     end
 
     it "creates MessageAugmentations" do
-      expect { subject.augment }.to change(MessageAugmentation, :count).from(0).to(2)
+      expect { subject.augment }.to change(MessageAugmentation, :count).from(0).to(3)
     end
 
     it "links the Message and the search hit references with MessageAugmentations" do
@@ -51,6 +71,7 @@ RSpec.describe PromptAugmentor do
       expect(MessageAugmentation.first.augmentation).to eq(search_hits.first.reference)
       expect(MessageAugmentation.second.message).to eq(message)
       expect(MessageAugmentation.second.augmentation).to eq(search_hits.second.reference)
+      expect(MessageAugmentation.third.augmentation).to eq(search_hits.third.reference)
     end
   end
 end


### PR DESCRIPTION
This seems to improve llm responses a little bit.

This PR replaces earlier one that got out of hand! My confusion was that the current ui can indicate that the prompt is being augment by showing `> augmentations` and there are none when you click the arrow.  I fixed that too, which I hope is ok.
