### PR TITLE
add soft delete to ModelServer

### DIFF
--- a/app/controllers/model_servers_controller.rb
+++ b/app/controllers/model_servers_controller.rb
@@ -26,7 +26,7 @@ class ModelServersController < ApplicationController
   def destroy
     respond_to do |format|
       format.html do
-        if @model_server.destroy
+        if @model_server.mark_as_deleted
           flash[:notice] = "Inference server deleted."
         else
           flash[:alert] = @model_server.errors.full_messages.join(";  ")

--- a/app/models/model_server.rb
+++ b/app/models/model_server.rb
@@ -65,4 +65,17 @@ class ModelServer < ApplicationRecord
     active_servers.update(active: false)
     update!(active: true)
   end
+
+  # soft deletion: move to concern when adding the second one
+  scope :deleted, -> { with_deleted.where.not(deleted_at: nil) }
+  scope :with_deleted, -> { unscope(where: :deleted_at) }
+  default_scope { where(deleted_at: nil) }
+
+  def mark_as_deleted
+    update(deleted_at: Time.current)
+  end
+
+  def restore
+    update(deleted_at: nil)
+  end
 end

--- a/db/migrate/20241029143102_add_deleted_at_to_model_server.rb
+++ b/db/migrate/20241029143102_add_deleted_at_to_model_server.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToModelServer < ActiveRecord::Migration[7.1]
+  def change
+    add_column :model_servers, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_24_190823) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_29_143102) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -241,6 +241,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_24_190823) do
     t.boolean "provisioned", default: false
     t.boolean "available", default: true
     t.string "api_key"
+    t.datetime "deleted_at"
   end
 
   create_table "motor_alert_locks", force: :cascade do |t|


### PR DESCRIPTION
- add soft delete to ModelServer
- use soft delete from Settings page

Soft delete is so the user doesn't accidentally delete ModelConfigs, Conversations, and therefore Messages when they delete a ModelServer.