### PR TITLE
ModelConfig has_many Collections

### DIFF
--- a/app/models/model_config.rb
+++ b/app/models/model_config.rb
@@ -5,9 +5,9 @@ class ModelConfig < ApplicationRecord
   has_many :conversations, dependent: :destroy
   belongs_to :model_server, optional: true
   has_many :embedding_collections, class_name: "Collection", inverse_of: :embedding_model_id,
-    dependent: restrict_with_exception
+    dependent: :restrict_with_exception
   has_many :extracting_collections, class_name: "Collection", inverse_of: :extraction_model_id,
-    dependent: restrict_with_exception
+    dependent: :restrict_with_exception
 
   scope :generation, -> { where(embedding: false).where(vision: false) }
   scope :embedding, -> { where(embedding: true) }

--- a/app/models/model_config.rb
+++ b/app/models/model_config.rb
@@ -4,6 +4,10 @@ class ModelConfig < ApplicationRecord
   has_many :messages, as: :author, dependent: :destroy
   has_many :conversations, dependent: :destroy
   belongs_to :model_server, optional: true
+  has_many :embedding_collections, class_name: "Collection", inverse_of: :embedding_model_id,
+    dependent: restrict_with_exception
+  has_many :extracting_collections, class_name: "Collection", inverse_of: :extraction_model_id,
+    dependent: restrict_with_exception
 
   scope :generation, -> { where(embedding: false).where(vision: false) }
   scope :embedding, -> { where(embedding: true) }


### PR DESCRIPTION
- add relationships between ModelConfig and Collection
- prevent deleting the ModelConfig if there are any Collections that use it for embedding or extraction, with `restrict_with_exception`