### PR TITLE
undelete server when adding new one with same args

### DIFF
--- a/app/models/model_config.rb
+++ b/app/models/model_config.rb
@@ -12,7 +12,11 @@ class ModelConfig < ApplicationRecord
   scope :generation, -> { where(embedding: false).where(vision: false) }
   scope :embedding, -> { where(embedding: true) }
   scope :vision, -> { where(vision: true) }
+
+  # soft deletion: move to concern when adding the third one :D
   default_scope { where(available: true) }
+  scope :unavailable, -> { with_deleted.where.not(available: false) }
+  scope :with_unavailable, -> { unscope(where: :available) }
 
   validate :model_type_flags_are_ok
 


### PR DESCRIPTION
- when the user is adding a new server, and there is a deleted one with the same args, undelete the old one instead of creating a new one

This is to allow the restoration of a server with models that were used in collections and conversations. Those collections and conversations will be usable again. If we created a new server, we could end up connected to the same remote endpoint, with all the same models, but Archyve would see it as a different server with different models.