### PR TITLE
remove default_scope from ModelServer and ModelConfig

### DIFF
--- a/app/controllers/model_servers_controller.rb
+++ b/app/controllers/model_servers_controller.rb
@@ -71,7 +71,8 @@ class ModelServersController < ApplicationController
     existing_but_deleted_server = ModelServer.deleted.find_by(**model_server_find_params)
 
     if existing_but_deleted_server.present?
-      existing_but_deleted_server.update(deleted_at: nil, api_key: model_server_find_params[:api_key])
+      existing_but_deleted_server.restore
+      existing_but_deleted_server.update(api_key: model_server_find_params[:api_key])
 
       existing_but_deleted_server
     else

--- a/app/controllers/v1/models_controller.rb
+++ b/app/controllers/v1/models_controller.rb
@@ -21,14 +21,16 @@ module V1
     end
 
     def model_config
-      ModelConfig.find_by(name: id_param) || ModelConfig.find_by(model: id_param) || ModelConfig.find(id_param)
+      ModelConfig.available.find_by(name: id_param) ||
+        ModelConfig.available.find_by(model: id_param) ||
+        ModelConfig.find(id_param)
     end
 
     def model_configs(embedding = nil)
-      return ModelConfig.embedding if embedding&.true?
-      return ModelConfig.generation if embedding&.false?
+      return ModelConfig.available.embedding if embedding&.true?
+      return ModelConfig.available.generation if embedding&.false?
 
-      ModelConfig.all
+      ModelConfig.available
     end
   end
 end

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -1,10 +1,10 @@
 module CollectionsHelper
   def embedding_model_list
-    ModelConfig.embedding
+    ModelConfig.available.embedding
   end
 
   def entity_extraction_model_list
-    ModelConfig.generation
+    ModelConfig.available.generation
   end
 
   def state_label_for(collection)

--- a/app/helpers/conversations_helper.rb
+++ b/app/helpers/conversations_helper.rb
@@ -1,6 +1,6 @@
 module ConversationsHelper
   def model_config_list
-    ModelConfig.generation
+    ModelConfig.available.generation
   end
 
   def collection_list(user)

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,10 +1,10 @@
 module SettingsHelper
   def embedding_model_list
-    ModelConfig.embedding
+    ModelConfig.available.embedding
   end
 
   def entity_extraction_model_list
-    ModelConfig.generation
+    ModelConfig.available.generation
   end
 
   def provider_list

--- a/app/models/model_config.rb
+++ b/app/models/model_config.rb
@@ -14,9 +14,8 @@ class ModelConfig < ApplicationRecord
   scope :vision, -> { where(vision: true) }
 
   # soft deletion: move to concern when adding the third one :D
-  default_scope { where(available: true) }
-  scope :unavailable, -> { with_deleted.where.not(available: false) }
-  scope :with_unavailable, -> { unscope(where: :available) }
+  scope :available, -> { where(available: true) }
+  scope :unavailable, -> { where(available: false) }
 
   validate :model_type_flags_are_ok
 

--- a/app/services/api/model_loader.rb
+++ b/app/services/api/model_loader.rb
@@ -10,7 +10,7 @@ module Api
 
     def model_config
       @model_config ||= if @model.present?
-        ModelConfig.find_by(name: @model) || ModelConfig.find_by(model: @model)
+        ModelConfig.available.find_by(name: @model) || ModelConfig.available.find_by(model: @model)
       else
         Setting.chat_model
       end

--- a/app/services/check_models_service.rb
+++ b/app/services/check_models_service.rb
@@ -14,9 +14,9 @@ class CheckModelsService
 
   def select_default_for_role(role)
     if role == "embedding"
-      Setting.get("#{role}_model", default: ModelConfig.embedding.last&.id)
+      Setting.get("#{role}_model", default: ModelConfig.available.embedding.last&.id)
     else
-      Setting.get("#{role}_model", default: ModelConfig.generation.last&.id)
+      Setting.get("#{role}_model", default: ModelConfig.available.generation.last&.id)
     end
   end
 

--- a/app/services/ollama/sync_models.rb
+++ b/app/services/ollama/sync_models.rb
@@ -61,8 +61,8 @@ module Ollama
     end
 
     def find_existing_model(model_details)
-      ModelConfig.where(model_server: nil)
-        .or(ModelConfig.where(model_server: @model_server))
+      ModelConfig.available.where(model_server: nil)
+        .or(ModelConfig.available.where(model_server: @model_server))
         .find_by(name: model_details.name, model: model_details.model)
     end
 

--- a/app/services/ollama_proxy/conversation_finder.rb
+++ b/app/services/ollama_proxy/conversation_finder.rb
@@ -39,7 +39,7 @@ module OllamaProxy
     end
 
     def chat_model_config
-      @chat_model_config ||= ModelConfig.find_or_create_by(model: @chat_request.model) do |model_config|
+      @chat_model_config ||= ModelConfig.available.find_or_create_by(model: @chat_request.model) do |model_config|
         model_config.name = @chat_request.model
         model_config.available = true
       end

--- a/app/services/ollama_proxy/message_creator.rb
+++ b/app/services/ollama_proxy/message_creator.rb
@@ -26,7 +26,7 @@ module OllamaProxy
     end
 
     def model_config
-      @model_config ||= ModelConfig.find_or_create_by(model: @chat_model) do |model_config|
+      @model_config ||= ModelConfig.available.find_or_create_by(model: @chat_model) do |model_config|
         model_config.name = @chat_model
         model_config.available = true
       end

--- a/app/views/conversations/_conversation_form.html.erb
+++ b/app/views/conversations/_conversation_form.html.erb
@@ -7,11 +7,21 @@
       value: conversation.title,
       onchange: "this.form.requestSubmit()"
     )%>
-    <%= f.collection_select(:model_config_id, model_config_list, :id, :name, {}, {
-      class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 mr-2",
-      onchange: "this.form.requestSubmit()",
-      disabled: conversation.messages.any? ? true : false
-    })%>
+    <% if conversation.model_config.available? %>
+      <%= f.collection_select(:model_config_id, model_config_list, :id, :name, {}, {
+        class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 mr-2",
+        onchange: "this.form.requestSubmit()",
+        disabled: conversation.messages.any? ? true : false,
+        title: conversation.messages.any? ? "The model cannot be changed after the conversation has started." : ""
+      })%>
+    <% else %>
+      <%= f.collection_select(:model_config_id, [conversation.model_config], :id, :name, {}, {
+        class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 mr-2",
+        onchange: "this.form.requestSubmit()",
+        disabled: true,
+        title: "This model is no longer available."
+      })%>
+    <% end %>
     <label class="inline-flex items-center cursor-pointer mr-2 mb-1 px-2 align-middle border border-secondary-400 rounded-lg h-full dark:bg-secondary-800">
       <%= f.check_box :search_collections, value: "", class: "sr-only peer", onchange: "this.form.requestSubmit()" %>
       <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-300 dark:peer-focus:ring-primary-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary-600"></div>

--- a/app/views/settings/_model_servers.html.erb
+++ b/app/views/settings/_model_servers.html.erb
@@ -2,7 +2,7 @@
 <div id="settings_model_servers">
   <div class="grid grid-cols-11 auto-cols-auto gap-4">
     <%= render "settings/server", server: nil %>
-    <% ModelServer.all.order(:id).each do |server| %>
+    <% ModelServer.available.order(:id).each do |server| %>
       <%= render "settings/server", server: %>
     <% end %>
   </div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -22,11 +22,11 @@
       <h2 class="mb-5 text-xl font-bold text-center text-secondary-700 dark:text-secondary-200">Models</h2>
       <div class="mb-20 flex justify-center items-center w-full">
         <div class="py-10 px-20 flex flex-col w-1/2 border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
-          <%= render "list_setting", setting: "entity_extraction_model", list: ModelConfig.generation %>
-          <%= render "list_setting", setting: "embedding_model", list: ModelConfig.embedding %>
-          <%= render "list_setting", setting: "summarization_model", list: ModelConfig.generation %>
-          <%= render "list_setting", setting: "chat_model", list: ModelConfig.generation %>
-          <%= render "list_setting", setting: "vision_model", list: ModelConfig.vision %>
+          <%= render "list_setting", setting: "entity_extraction_model", list: ModelConfig.available.generation %>
+          <%= render "list_setting", setting: "embedding_model", list: ModelConfig.available.embedding %>
+          <%= render "list_setting", setting: "summarization_model", list: ModelConfig.available.generation %>
+          <%= render "list_setting", setting: "chat_model", list: ModelConfig.available.generation %>
+          <%= render "list_setting", setting: "vision_model", list: ModelConfig.available.vision %>
         </div>
       </div>
 
@@ -34,11 +34,11 @@
       <h2 class="mb-5 text-xl font-bold text-center text-secondary-500 dark:text-secondary-200">Search</h2>
       <div class="mb-20 flex justify-center items-center w-full ">
         <div class="py-10 px-20 flex flex-col w-3/4 border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
-          <%= render "number_setting", setting: "distance_ratio_threshold", list: ModelConfig.generation, step: 0.01 %>
+          <%= render "number_setting", setting: "distance_ratio_threshold", list: ModelConfig.available.generation, step: 0.01 %>
           <div class="mb-10 text-secondary-400 dark:text-secondary-400">Archyve uses a filter on search results that detects when one result is significantly less relevant than the previous result - a sudden drop in relevance while traversing search results. This value controls how large a drop will trigger Archyve to consider all results after the drop irrelevant.</div>
-          <%= render "number_setting", setting: "normalized_search_distance_ceiling", list: ModelConfig.generation, step: 0.1 %>
+          <%= render "number_setting", setting: "normalized_search_distance_ceiling", list: ModelConfig.available.generation, step: 0.1 %>
           <div class="mb-10 text-secondary-400 dark:text-secondary-400">Archyve uses a filter on search results that discards any result with a distance score (higher is less relevant) above this threshold.</div>
-          <%= render "number_setting", setting: "num_chunks_to_include", list: ModelConfig.generation, step: 1 %>
+          <%= render "number_setting", setting: "num_chunks_to_include", list: ModelConfig.available.generation, step: 1 %>
           <div class="mb-10 text-secondary-400 dark:text-secondary-400">This setting controls the maximum number of relevant chunks Archyve will include in search results or when augmenting a prompt.</div>
         </div>
       </div>
@@ -47,9 +47,9 @@
       <h2 class="mb-5 text-xl font-bold text-center text-secondary-500 dark:text-secondary-200">Ollama Proxy Port (OPP)</h2>
       <div class="mb-20 flex justify-center items-center w-full ">
         <div class="py-10 px-20 flex flex-col w-3/4 border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
-          <%= render "number_setting", setting: "opp_num_conversation_title_chars", list: ModelConfig.generation, step: 1 %>
+          <%= render "number_setting", setting: "opp_num_conversation_title_chars", list: ModelConfig.available.generation, step: 1 %>
           <div class="mb-10 text-secondary-400 dark:text-secondary-400">When creating a conversation based on a request to the OPP, this setting controls how many characters from the first chat message will be used in the conversation title.</div>
-          <%= render "number_setting", setting: "opp_num_recent_convos_for_match", list: ModelConfig.generation, step: 1 %>
+          <%= render "number_setting", setting: "opp_num_recent_convos_for_match", list: ModelConfig.available.generation, step: 1 %>
           <div class="mb-10 text-secondary-400 dark:text-secondary-400">When a message is received by the OPP, Archyve looks through its recent conversations to attempt to find a matching one. If it finds a match, it appends the new message to that conversation instead of creating a new conversation. This setting controls how far back Archyve will look for a matching conversation.</div>
         </div>
       </div>

--- a/db/migrate/20240506125220_add_default_to_model_config.rb
+++ b/db/migrate/20240506125220_add_default_to_model_config.rb
@@ -3,7 +3,7 @@ class AddDefaultToModelConfig < ActiveRecord::Migration[7.1]
     add_column :model_configs, :default, :boolean, default: false
 
     # use most recent models as defaults
-    ModelConfig.where(embedding: true).last&.update!(default: true)
-    ModelConfig.where(embedding: false).last&.update!(default: true)
+    ModelConfig.available.where(embedding: true).last&.update!(default: true)
+    ModelConfig.available.where(embedding: false).last&.update!(default: true)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -113,7 +113,7 @@ provisioned_model_configs.each do |fields|
   fields.slice!(*model_config_fields)
   puts "provisioning model configuration for `#{fields}` ..."
 
-  model_config = ModelConfig.find_or_initialize_by(name: fields["name"])
+  model_config = ModelConfig.available.find_or_initialize_by(name: fields["name"])
   model_config.update!(**fields, provisioned: true)
   if server
     model_server = ModelServer.find_by(name: server)
@@ -125,19 +125,19 @@ end
 # SETTINGS
 #
 Setting.find_or_create_by!(key: "chat_model") do |setting|
-  setting.value = ModelConfig.generation.last&.id
+  setting.value = ModelConfig.available.generation.last&.id
 end
 
 Setting.find_or_create_by!(key: "embedding_model") do |setting|
-  setting.value = ModelConfig.embedding.last&.id
+  setting.value = ModelConfig.available.embedding.last&.id
 end
 
 Setting.find_or_create_by!(key: "summarization_model") do |setting|
-  setting.value = ModelConfig.generation.last&.id
+  setting.value = ModelConfig.available.generation.last&.id
 end
 
 Setting.find_or_create_by!(key: "entity_extraction_model") do |setting|
-  setting.value = ModelConfig.generation.last&.id
+  setting.value = ModelConfig.available.generation.last&.id
 end
 
 Setting.find_or_create_by!(key: "num_chunks_to_include") do |setting|

--- a/spec/e2e/api/chat_spec.rb
+++ b/spec/e2e/api/chat_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "/v1/chat", :api, :llm, :slow, type: :system do
+RSpec.describe "/v1/chat", :api, :llm, :now, :slow, type: :system do
   let(:call) { api_get("/v1/chat?prompt=hello") }
   let(:conversation_id) { @call.parsed_body["conversation"] }
   let(:conversation_call) { api_get("/v1/conversations/#{conversation_id}") }


### PR DESCRIPTION
- remove default scope from ModelConfig and ModelServer
- just insert `.available` on a ton of calls to these model classes

Implementing soft delete using `default_scope` was problematic. Even if a model had a reference to another model by ID, it couldn't find the other model. Also, `dependent: destroy` was broken and needed to be implemented in a separate callback.