### PR TITLE
check that extraction model context window is big enough

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -31,7 +31,7 @@ class CollectionsController < ApplicationController
   end
 
   def create
-    @collection = collection_from_params(collection_params)
+    @collection = Collection.new(collection_params)
 
     if @collection.save
       @collection.generate_slug
@@ -130,17 +130,6 @@ class CollectionsController < ApplicationController
   end
 
   private
-
-  def collection_from_params(params)
-    @collection = Collection.new(params)
-    @collection.embedding_model = if params[:embedding_model_id]
-      ModelConfig.find(params[:embedding_model_id])
-    else
-      Setting.embedding_model
-    end
-
-    @collection
-  end
 
   def collection_params
     params.require(:collection).permit(:name, :graph_enabled, :embedding_model_id, :entity_extraction_model_id)

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -21,7 +21,7 @@ class ConversationsController < ApplicationController
     unless Setting.chat_model && Setting.embedding_model && Setting.summarization_model
       return redirect_to(
         conversations_path,
-        alert: "Please ask your admin to set the chat model, embedding model and summarization model in the admin UI."
+        alert: "Please set the chat model, embedding model and summarization model on the Settings page."
       )
     end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -18,7 +18,6 @@ class ConversationsController < ApplicationController
   # rubocop:disable Metrics/AbcSize
   # POST /conversations or /conversations.json
   def create
-    binding.pry
     unless Setting.chat_model && Setting.embedding_model && Setting.summarization_model
       return redirect_to(
         conversations_path,

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -18,6 +18,7 @@ class ConversationsController < ApplicationController
   # rubocop:disable Metrics/AbcSize
   # POST /conversations or /conversations.json
   def create
+    binding.pry
     unless Setting.chat_model && Setting.embedding_model && Setting.summarization_model
       return redirect_to(
         conversations_path,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,15 @@ module ApplicationHelper
     num_bgs = Rails.configuration.dark_backgrounds.length
     Rails.configuration.dark_backgrounds[rand(0..num_bgs - 1)]
   end
+
+  def entity_extraction_model_list
+    ModelConfig.available.generation.where(
+      "context_window_size >= ?",
+      min_context_window_size
+    ).order(context_window_size: :desc)
+  end
+
+  def min_context_window_size
+    @min_context_window_size ||= Graph::CalculateMinContextSize.new.execute
+  end
 end

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -3,10 +3,6 @@ module CollectionsHelper
     ModelConfig.available.embedding
   end
 
-  def entity_extraction_model_list
-    ModelConfig.available.generation
-  end
-
   def state_label_for(collection)
     state_text = state_text_for(collection)
     return state_text unless state_text.end_with?("ing")
@@ -33,5 +29,14 @@ module CollectionsHelper
     return distance.round if distance > 10
 
     distance.round(2)
+  end
+
+  def entity_extraction_model_for(collection)
+    return collection.entity_extraction_model&.name if collection.entity_extraction_model.present?
+
+    global_model = ModelConfig.find_by(id: Setting.get("entity_extraction_model"))
+    return global_model.name if global_model.present?
+
+    "No extraction model"
   end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,13 +1,9 @@
 module SettingsHelper
-  def embedding_model_list
-    ModelConfig.available.embedding
-  end
-
-  def entity_extraction_model_list
+  def settings_entity_extraction_model_list
     ModelConfig.available.generation
   end
 
-  def provider_list
+  def settings_provider_list
     options_for_select(ModelServer.providers.map { |name, _int| [name.humanize.capitalize, name] })
   end
 end

--- a/app/models/model_config.rb
+++ b/app/models/model_config.rb
@@ -66,6 +66,8 @@ class ModelConfig < ApplicationRecord
 
   def mark_as_unavailable
     update(available: false)
+
+    Setting.settings_for_model_id(id).destroy_all
   end
 
   private

--- a/app/models/model_config.rb
+++ b/app/models/model_config.rb
@@ -70,6 +70,10 @@ class ModelConfig < ApplicationRecord
     Setting.settings_for_model_id(id).destroy_all
   end
 
+  def descriptor
+    "#{model_server.name || active_server.name}/#{name}"
+  end
+
   private
 
   def active_server

--- a/app/models/model_server.rb
+++ b/app/models/model_server.rb
@@ -74,7 +74,7 @@ class ModelServer < ApplicationRecord
   def mark_as_deleted
     model_configs.find_each { |model_config| model_config.update!(available: false) }
 
-    update(deleted_at: Time.current)
+    update(deleted_at: Time.current, active: false)
   end
 
   def restore

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -50,7 +50,7 @@ class Setting < ApplicationRecord
       model_id = find_by(key: "#{role}_model")&.value
       return if model_id.nil?
 
-      ModelConfig.find(model_id)
+      ModelConfig.available.find_by(id: model_id)
     end
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -46,6 +46,12 @@ class Setting < ApplicationRecord
       model_for("entity_extraction")
     end
 
+    def settings_for_model_id(id)
+      where("key LIKE ?", "%_model").where(value: id)
+    end
+
+    private
+
     def model_for(role)
       model_id = find_by(key: "#{role}_model")&.value
       return if model_id.nil?

--- a/app/services/check_models_service.rb
+++ b/app/services/check_models_service.rb
@@ -1,13 +1,11 @@
 class CheckModelsService
-  MODEL_ROLES = %w[chat summarization embedding entity_extraction].freeze
+  MODEL_ROLES = %w[chat summarization embedding].freeze
 
   def execute
     missing_roles = detect_missing_roles
     return if missing_roles.empty?
 
-    missing_roles.each { |role| select_default_for_role(role) }
-
-    detect_missing_roles
+    missing_roles
   end
 
   private
@@ -22,12 +20,6 @@ class CheckModelsService
 
   def detect_missing_roles
     MODEL_ROLES - defined_roles
-  end
-
-  def warning_string_for(roles)
-    "No model defined for roles #{roles.join(", ")}.
-
-    Define a ModelConfig in Admin -> ModelConfigs and then click 'Use for <role>."
   end
 
   def defined_roles

--- a/app/services/graph/calculate_min_context_size.rb
+++ b/app/services/graph/calculate_min_context_size.rb
@@ -1,0 +1,25 @@
+module Graph
+  class CalculateMinContextSize
+    AVG_CHARACTERS_PER_TOKEN = 4
+    # TODO: this is also defined in documents_helper.rb; should be in one place
+    DEFAULT_CHUNK_SIZE = 1000
+
+    def execute
+      return existing_calculation if existing_calculation
+
+      Setting.set("kg_min_context_window_size", calculation)
+
+      calculation
+    end
+
+    private
+
+    def existing_calculation
+      @existing_calculation ||= Setting.get("kg_min_context_window_size")
+    end
+
+    def calculation
+      @calculation ||= (Prompts::ENTITY_EXTRACTION_PROMPT.size + DEFAULT_CHUNK_SIZE) / AVG_CHARACTERS_PER_TOKEN
+    end
+  end
+end

--- a/app/services/graph/extract_chunk_entities.rb
+++ b/app/services/graph/extract_chunk_entities.rb
@@ -44,7 +44,7 @@ module Graph
 
     def entity_extraction_model_id
       @document.collection.entity_extraction_model&.id ||
-        Setting.get("entity_extraction_model", default: Setting.chat_model.id)
+        Setting.get("entity_extraction_model")
     end
   end
 end

--- a/app/views/collections/_new.html.erb
+++ b/app/views/collections/_new.html.erb
@@ -19,7 +19,7 @@
       <div class="py-4 items-center flex">
         <%= f.label "Embedding model", class: "pr-4" %>
         <div class="flex-1"></div>
-        <%= f.collection_select(:embedding_model_id, embedding_model_list, :id, :name, {}, {
+        <%= f.collection_select(:embedding_model_id, embedding_model_list, :id, :descriptor, {}, {
           class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800"
         })%>
       </div>
@@ -37,7 +37,7 @@
             <div class="flex items-center">
               <%= f.label "Entity extraction model", class: "pr-4" %>
               <div class="flex-1"></div>
-              <%= f.collection_select(:entity_extraction_model_id, entity_extraction_model_list, :id, :name, {
+              <%= f.collection_select(:entity_extraction_model_id, entity_extraction_model_list, :id, :descriptor, {
                 include_blank: true
               }, {
                 class: "flex-1 rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800"

--- a/app/views/collections/_new.html.erb
+++ b/app/views/collections/_new.html.erb
@@ -4,41 +4,57 @@
   <div class="p-4">
     <% flash[:error]&.each do |error| %><div class="rounded-lg px-2 p-1 bg-error-400 dark:bg-error-800"><%= error %></div><% end %>  
   </div>
-  <%= form_for collection do |f| %>
-    <div class="py-4 items-center flex">
-      <%= f.text_field(
-        :name,
-        class: "rounded-md bg-secondary-50 dark:bg-secondary-800 flex-1",
-        value: collection.name,
-        placeholder: "New collection name",
-        autofocus: true
-      )%>
-      <%= f.submit "Update", hidden: true %>
-    </div>
-    <div class="py-4 items-center flex">
-      <%= f.label "Embedding model", class: "pr-4" %>
-      <%= f.collection_select(:embedding_model_id, embedding_model_list, :id, :name, {}, {
-        class: "flex-1 rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800"
-      })%>
-    </div>
-    <div class="py-4 items-center flex">
-      <%= f.label "Entity extraction model", class: "pr-4" %>
-      <%= f.collection_select(:entity_extraction_model_id, entity_extraction_model_list, :id, :name, {}, {
-        class: "flex-1 rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800"
-      })%>
-    </div>
-    <div class="flex py-4 items-center justify-start">
-      <label class="inline-flex items-center cursor-pointer mb-1 align-middle rounded-lg w-full">
-        <%= f.check_box :graph_enabled, value: "", class: "sr-only peer" %>
-        <span class="mr-3 text-sm font-medium text-gray-900 dark:text-gray-300">Knowledge Graph enabled</span>
+  <div class="sm:w-full md:w-4/5 lg:w-3/5 xl:w-[580px]">
+    <%= form_for collection do |f| %>
+      <div class="py-4 items-center flex">
+        <%= f.text_field(
+          :name,
+          class: "rounded-md bg-secondary-50 dark:bg-secondary-800 flex-1",
+          value: collection.name,
+          placeholder: "New collection name",
+          autofocus: true
+        )%>
+        <%= f.submit "Update", hidden: true %>
+      </div>
+      <div class="py-4 items-center flex">
+        <%= f.label "Embedding model", class: "pr-4" %>
         <div class="flex-1"></div>
-        <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-300 dark:peer-focus:ring-primary-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary-600"></div>
-      </label>
-    </div>
-    <div class="flex p-2 items-center">
-      <div class="flex-1"></div>
-      <%= f.submit "Create", class: "rounded-lg py-1 px-3 text-center text-secondary-100 dark:text-secondary-950 block font-medium bg-tertiary-600 dark:bg-tertiary-400" %>
-    </div>
-  <% end %>
+        <%= f.collection_select(:embedding_model_id, embedding_model_list, :id, :name, {}, {
+          class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800"
+        })%>
+      </div>
+      <div class="border border-secondary-400 dark:border-secondary-300 shadow-lg rounded-lg p-10 mt-8 w-full">
+        <div class="flex py-4 items-center justify-start">
+          <label class="inline-flex items-center cursor-pointer mb-1 align-middle rounded-lg w-full">
+            <%= f.check_box :graph_enabled, value: "", class: "sr-only peer" %>
+            <span class="mr-3 text-sm font-medium text-gray-900 dark:text-gray-300">Knowledge Graph enabled</span>
+            <div class="flex-1"></div>
+            <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-300 dark:peer-focus:ring-primary-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary-600"></div>
+          </label>
+        </div>
+        <div class="py-4 items-center flex">
+          <div class="flex flex-col">
+            <div class="flex items-center">
+              <%= f.label "Entity extraction model", class: "pr-4" %>
+              <div class="flex-1"></div>
+              <%= f.collection_select(:entity_extraction_model_id, entity_extraction_model_list, :id, :name, {
+                include_blank: true
+              }, {
+                class: "flex-1 rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800"
+              })%>
+            </div>
+            <div class="text-sm text-secondary-500 mt-4">
+              <div>Archyve requires a context window of at least <%= min_context_window_size %> tokens to reliably perform entity extraction. This list has been filtered to those models.</div>
+              <div class="py-2">Leave blank to use the global setting.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="flex p-2 items-center">
+        <div class="flex-1"></div>
+        <%= f.submit "Create", class: "rounded-lg py-1 px-3 text-center text-secondary-100 dark:text-secondary-950 block font-medium bg-tertiary-600 dark:bg-tertiary-400" %>
+      </div>
+    <% end %>
+  </div>
   
 </div>

--- a/app/views/collections/_state_tags.html.erb
+++ b/app/views/collections/_state_tags.html.erb
@@ -4,11 +4,9 @@
   <div class="px-2 py-1 rounded-lg text-xs bg-secondary-300 dark:bg-secondary-700 text-secondary-800 dark:text-secondary-200">
     <%= collection.embedding_model.name %>
   </div>
-  <% if collection.entity_extraction_model.present? %>
-    <div class="p-1 px-2 ms-2 rounded-lg text-xs bg-secondary-300 dark:bg-secondary-700 text-secondary-800 dark:text-secondary-200">
-      <%= collection.entity_extraction_model.name %>
-    </div>
-   <% end %>
+  <div class="p-1 px-2 ms-2 rounded-lg text-xs bg-secondary-300 dark:bg-secondary-700 text-secondary-800 dark:text-secondary-200">
+    <%= entity_extraction_model_for(collection) %>
+  </div>
   <% if collection.graph_enabled %>
     <% if collection.state == "errored" %>
       <div class="p-1 px-2 ms-2 rounded-lg text-xs text-secondary-800 dark:text-secondary-200 bg-error-400 dark:bg-error-800" title="<%= collection.error_message %>">

--- a/app/views/settings/_list_setting.html.erb
+++ b/app/views/settings/_list_setting.html.erb
@@ -6,7 +6,8 @@
     <div class="items-center flex">
       <%= f.label setting.titleize, class: "pr-4" %>
       <div class="flex-1"></div>
-      <%= f.collection_select(:value, list, :id, :name, {
+      <% field = list.all? { |item| item.respond_to?(:descriptor) } ? :descriptor : :name %>
+      <%= f.collection_select(:value, list, :id, field, {
         prompt: "Select an option..."
       }, {
         class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800",

--- a/app/views/settings/_list_setting.html.erb
+++ b/app/views/settings/_list_setting.html.erb
@@ -1,14 +1,22 @@
 <% setting_model = Setting.ensure_exists(setting) %>
+<% help_text ||= nil %>
 
 <%= form_for setting_model do |f| %>
-  <div class="py-4 items-center flex">
-    <%= f.label setting.titleize, class: "pr-4" %>
-    <div class="flex-1"></div>
-    <%= f.collection_select(:value, list, :id, :name, {
-      prompt: "Select an option..."
-    }, {
-      class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800",
-      onchange: "this.form.submit()"
-    })%>
+  <div class="py-4 flex-col">
+    <div class="items-center flex">
+      <%= f.label setting.titleize, class: "pr-4" %>
+      <div class="flex-1"></div>
+      <%= f.collection_select(:value, list, :id, :name, {
+        prompt: "Select an option..."
+      }, {
+        class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800",
+        onchange: "this.form.submit()"
+      })%>
+    </div>
+    <% if help_text.present? %>
+      <div class="text-sm text-secondary-500 pb-1 whitespace-pre-line">
+        <div><%= help_text %></div>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/settings/_model_servers.html.erb
+++ b/app/views/settings/_model_servers.html.erb
@@ -1,6 +1,6 @@
 <% model_server ||= @model_server %>
 <div id="settings_model_servers">
-  <div class="grid grid-cols-11 auto-cols-auto gap-4">
+  <div class="grid grid-cols-11 gap-4">
     <%= render "settings/server", server: nil %>
     <% ModelServer.available.order(:id).each do |server| %>
       <%= render "settings/server", server: %>

--- a/app/views/settings/_number_setting.html.erb
+++ b/app/views/settings/_number_setting.html.erb
@@ -1,16 +1,24 @@
 <% setting_model = Setting.ensure_exists(setting) %>
+<% help_text ||= nil %>
 
 <%= form_for setting_model do |f| %>
-  <div class="py-4 items-center flex">
-    <%= f.label setting.titleize, class: "pr-4" %>
-    <div class="flex-1"></div>
-    <%= f.number_field(
-      :value,
-      class: "rounded-md bg-secondary-200 dark:bg-secondary-800 mx-1",
-      value: setting_model.value,
-      onchange: "this.form.requestSubmit()",
-      step:,
-      min: step
-    )%>
+  <div class="py-4 flex-col">
+    <div class="items-center flex">
+      <%= f.label setting.titleize, class: "pr-4" %>
+      <div class="flex-1"></div>
+      <%= f.number_field(
+        :value,
+        class: "rounded-md bg-secondary-200 dark:bg-secondary-800 mx-1",
+        value: setting_model.value,
+        onchange: "this.form.requestSubmit()",
+        step:,
+        min: step
+      )%>
+    </div>
+    <% if help_text.present? %>
+      <div class="text-sm text-secondary-400 dark:text-secondary-500 pb-1 whitespace-pre-line">
+        <div><%= help_text %></div>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/settings/_select_setting.html.erb
+++ b/app/views/settings/_select_setting.html.erb
@@ -1,6 +1,6 @@
 <div class="py-4 items-center flex">
   <%= f.label setting.key.titleize, class: "pr-4" %>
-  <%= f.collection_select(:entity_extraction_model_id, entity_extraction_model_list, :id, :name, {}, {
+  <%= f.collection_select(:entity_extraction_model_id, settings_entity_extraction_model_list, :id, :name, {}, {
     class: "flex-1 rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800"
   })%>
 </div>

--- a/app/views/settings/_server_form.erb
+++ b/app/views/settings/_server_form.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="mr-4 mt-2">
         <%= f.select :provider,
-          provider_list,
+          settings_provider_list,
           { prompt: "Provider..." },
           { class: "pr-2 py-1 rounded-lg bg-secondary-50 dark:bg-secondary-950 flex-1" }
         %>
@@ -37,7 +37,7 @@
       </div>
       <div>
         <%= f.submit 'Add',
-          class: "px-4 py-2 rounded-lg text-secondary-900 dark:text-secondary-100 bg-secondary-50 dark:bg-secondary-800"
+          class: "px-4 py-2 rounded-lg text-secondary-900 dark:text-secondary-100 bg-secondary-200 dark:bg-secondary-800"
         %>
       </div>
     </div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -13,7 +13,7 @@
       <!-- SERVERS -->
       <h2 class="mb-5 text-secondary-700 dark:text-secondary-200 text-xl font-bold text-center">Inference servers</h2>
       <div class="mb-20 flex justify-center items-center w-full">
-        <div class="py-10 px-10 flex flex-col w-3/4 border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
+        <div class="py-10 px-10 flex flex-col sm:w-full md:w-full lg:w-4/5 xl:w-3/5 2xl:w-[640px] border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
           <%= render "model_servers" %>
         </div>
       </div>
@@ -21,10 +21,31 @@
       <!-- MODELS -->
       <h2 class="mb-5 text-xl font-bold text-center text-secondary-700 dark:text-secondary-200">Models</h2>
       <div class="mb-20 flex justify-center items-center w-full">
-        <div class="py-10 px-20 flex flex-col w-1/2 border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
-          <%= render "list_setting", setting: "entity_extraction_model", list: ModelConfig.available.generation %>
-          <%= render "list_setting", setting: "embedding_model", list: ModelConfig.available.embedding %>
-          <%= render "list_setting", setting: "summarization_model", list: ModelConfig.available.generation %>
+        <div class="py-10 px-10 flex flex-col sm:w-full md:w-4/5 lg:w-3/5 xl:w-1/2 2xl:w-[640px] border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
+          <%= render "list_setting",
+            setting: "entity_extraction_model",
+            list: entity_extraction_model_list,
+            help_text: <<~EXTRACTION_HELP
+              Archyve requires a context window of at least #{min_context_window_size} to reliably perform entity extraction. This list has been filtered to those models.
+              
+              Archyve will fall back to this model if a collection does not have an entity extraction model set.
+            EXTRACTION_HELP
+          %>
+          <%= render "list_setting",
+            setting: "embedding_model",
+            list: ModelConfig.available.embedding,
+            help_text: <<~EMBEDDING_HELP
+              Archyve will fall back to this model if a collection does not have an embedding model set.
+            EMBEDDING_HELP
+          %>
+          <%= render "list_setting",
+            setting: "summarization_model",
+            list: ModelConfig.available.generation,
+            help_text: <<~SUMMARIZATION_HELP
+              Archyve will use this model to summarize prompts given by the user in chat. Those summaries are used as the titles of conversations.
+            SUMMARIZATION_HELP
+
+          %>
           <%= render "list_setting", setting: "chat_model", list: ModelConfig.available.generation %>
           <%= render "list_setting", setting: "vision_model", list: ModelConfig.available.vision %>
         </div>
@@ -33,24 +54,54 @@
       <!-- SEARCH -->
       <h2 class="mb-5 text-xl font-bold text-center text-secondary-500 dark:text-secondary-200">Search</h2>
       <div class="mb-20 flex justify-center items-center w-full ">
-        <div class="py-10 px-20 flex flex-col w-3/4 border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
-          <%= render "number_setting", setting: "distance_ratio_threshold", list: ModelConfig.available.generation, step: 0.01 %>
-          <div class="mb-10 text-secondary-400 dark:text-secondary-400">Archyve uses a filter on search results that detects when one result is significantly less relevant than the previous result - a sudden drop in relevance while traversing search results. This value controls how large a drop will trigger Archyve to consider all results after the drop irrelevant.</div>
-          <%= render "number_setting", setting: "normalized_search_distance_ceiling", list: ModelConfig.available.generation, step: 0.1 %>
-          <div class="mb-10 text-secondary-400 dark:text-secondary-400">Archyve uses a filter on search results that discards any result with a distance score (higher is less relevant) above this threshold.</div>
-          <%= render "number_setting", setting: "num_chunks_to_include", list: ModelConfig.available.generation, step: 1 %>
-          <div class="mb-10 text-secondary-400 dark:text-secondary-400">This setting controls the maximum number of relevant chunks Archyve will include in search results or when augmenting a prompt.</div>
+        <div class="py-10 px-20 flex flex-col sm:w-full md:w-full lg:w-4/5 xl:w-3/5 2xl:w-[880px] border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
+          <%= render "number_setting",
+            setting: "distance_ratio_threshold",
+            list: ModelConfig.available.generation,
+            step: 0.01,
+            help_text: <<~DRT_HELP
+              Archyve uses a filter on search results that detects when one result is significantly less relevant than the previous result - a sudden drop in relevance while traversing search results. This value controls how large a drop will trigger Archyve to consider all results after the drop irrelevant.
+            DRT_HELP
+          %>
+          <%= render "number_setting",
+            setting: "normalized_search_distance_ceiling",
+            list: ModelConfig.available.generation,
+            step: 0.1,
+            help_text: <<~NSD_CEILING_HELP
+              Archyve uses a filter on search results that discards any result with a distance score (higher is less relevant) above this threshold.
+            NSD_CEILING_HELP
+          %>
+          <%= render "number_setting",
+            setting: "num_chunks_to_include",
+            list: ModelConfig.available.generation,
+            step: 1,
+            help_text: <<~NUM_CHUNKS_HELP
+              This setting controls the maximum number of relevant chunks Archyve will include in search results or when augmenting a prompt.
+            NUM_CHUNKS_HELP
+          %>
         </div>
       </div>
 
       <!-- OPP -->
       <h2 class="mb-5 text-xl font-bold text-center text-secondary-500 dark:text-secondary-200">Ollama Proxy Port (OPP)</h2>
       <div class="mb-20 flex justify-center items-center w-full ">
-        <div class="py-10 px-20 flex flex-col w-3/4 border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
-          <%= render "number_setting", setting: "opp_num_conversation_title_chars", list: ModelConfig.available.generation, step: 1 %>
-          <div class="mb-10 text-secondary-400 dark:text-secondary-400">When creating a conversation based on a request to the OPP, this setting controls how many characters from the first chat message will be used in the conversation title.</div>
-          <%= render "number_setting", setting: "opp_num_recent_convos_for_match", list: ModelConfig.available.generation, step: 1 %>
-          <div class="mb-10 text-secondary-400 dark:text-secondary-400">When a message is received by the OPP, Archyve looks through its recent conversations to attempt to find a matching one. If it finds a match, it appends the new message to that conversation instead of creating a new conversation. This setting controls how far back Archyve will look for a matching conversation.</div>
+        <div class="py-10 px-20 flex flex-col sm:w-full md:w-full lg:w-4/5 xl:w-3/5 2xl:w-[880px] border border-secondary-300 dark:border-secondary-600 rounded-lg shadow-lg hover:border-secondary-900 hover:dark:border-secondary-500 min-w-min">
+          <%= render "number_setting",
+            setting: "opp_num_conversation_title_chars",
+            list: ModelConfig.available.generation,
+            step: 1,
+            help_text: <<~OPP_NUM_TITLE_CHARS_HELP
+              When creating a conversation based on a request to the OPP, this setting controls how many characters from the first chat message will be used in the conversation title.
+            OPP_NUM_TITLE_CHARS_HELP
+          %>
+          <%= render "number_setting",
+            setting: "opp_num_recent_convos_for_match",
+            list: ModelConfig.available.generation,
+            step: 1,
+            help_text: <<~OPP_NUM_RECENT_CONVOS_HELP
+              When a message is received by the OPP, Archyve looks through its recent conversations to attempt to find a matching one. If it finds a match, it appends the new message to that conversation instead of creating a new conversation. This setting controls how far back Archyve will look for a matching conversation.
+            OPP_NUM_RECENT_CONVOS_HELP
+          %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_model_warnings.html.erb
+++ b/app/views/shared/_model_warnings.html.erb
@@ -1,13 +1,11 @@
 <% if @missing_models.present? %>
-  <div class="pb-2 mx-12">
-    <div class="rounded-lg bg-warning-400 dark:bg-warning-900 p-4 m-2 text-center">
-      <div class="text-secondary-600 dark:text-secondary-200">
-        There is no model configured for some roles: <span class="font-bold"><%= @missing_models.join(", ") %></span>.
-        <br>
-        <br>
-        Please create an embedding ModelConfig for these roles in
-        <%= link_to "Admin > ModelConfigs", href="/admin/data/model_configs", class: "text-secondary-700 dark:text-secondary-100 font-bold" %>
-        .
+  <div class="mx-12">
+    <div class="rounded-lg m-2 text-center bg-warning-500 dark:bg-warning-900">
+      <div class="">
+        <p>
+          There are no models configured for some roles: <span class="font-bold"><%= @missing_models.join(", ") %></span>.
+          Please select models to use for these roles on <%= link_to "the Settings page", settings_path, class: "font-bold hover:underline" %>.
+        </p>
       </div>
     </div>
   </div>

--- a/app/views/shared/_notice.html.erb
+++ b/app/views/shared/_notice.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= user_dom_id("notice") %>" class="flex justify-center align-center fixed">
-  <% if notice %>
-    <p class="text-sm notice opacity-0 text-secondary-600 dark:text-secondary-400 animate-fade"><%= notice %></p>
-  <% elsif alert %>
-    <p class="text-sm alert opacity-0 text-tertiary-700 animate-fade"><%= alert %></p>
-  <% end %>
+      <% if notice %>
+        <p class="text-sm notice opacity-0 text-secondary-600 dark:text-secondary-400 animate-fade"><%= notice %></p>
+      <% elsif alert %>
+        <p class="text-sm alert opacity-0 text-tertiary-700 animate-fade"><%= alert %></p>
+      <% end %>
 </div>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -85,7 +85,7 @@ module.exports = {
         },
       },
       animation: {
-        fade: "fadeOut 3s ease-in-out",
+        fade: "fadeOut 5s ease-in-out",
       },
 
       // that is actual animation

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -136,10 +136,6 @@ Setting.find_or_create_by!(key: "summarization_model") do |setting|
   setting.value = ModelConfig.available.generation.last&.id
 end
 
-Setting.find_or_create_by!(key: "entity_extraction_model") do |setting|
-  setting.value = ModelConfig.available.generation.last&.id
-end
-
 Setting.find_or_create_by!(key: "num_chunks_to_include") do |setting|
   setting.value = 5
 end

--- a/modelfiles/llama3.1_4096:latest
+++ b/modelfiles/llama3.1_4096:latest
@@ -1,0 +1,4 @@
+FROM llama3.1:latest
+
+PARAMETER num_ctx 4096
+


### PR DESCRIPTION
- check that context window size of extraction model is big enough
- filter contents of extraction model selection dropdowns to only models with big enough ctx windows
- add help text to explain to user that this filtering is occurring
- stop auto-setting models on every page load; they were just wrong
- warn user at top of page if there is no embedding or chat model, but don't warn for missing extraction model (user may need to do work to create an eligible model, and they can just not use KG for now)
- make settings page responsive
- make Collections#new page responsive