### PR TITLE
fix e2e spec that didn't handle html documents

### DIFF
--- a/spec/support/api/schemas/documents.json
+++ b/spec/support/api/schemas/documents.json
@@ -19,7 +19,7 @@
           "id": { "type": "integer" },
           "collection_id": { "type": "integer" },
           "user_id": { "type": "integer" },
-          "filename": { "type": "string" },
+          "filename": { "type": ["string", "null"] },
           "state": { "type": "string" },
           "vector_id": { "type": ["integer", "null"] },
           "chunking_profile_id": { "type": "integer" }


### PR DESCRIPTION
- fix test that wasn't expecting "Documents" from URLs