### PR TITLE
Refactor Chunk properties, and update all related code to reflect changes

### DIFF
--- a/app/controllers/v1/chunks_controller.rb
+++ b/app/controllers/v1/chunks_controller.rb
@@ -44,7 +44,8 @@ module V1
     end
 
     def render_attributes
-      %w[id document_id content embedding_content entities_extracted vector_id created_at updated_at]
+      %w[id document_id excerpt embedding_content headings surrounding_content location_summary entities_extracted
+         vector_id created_at updated_at]
     end
   end
 end

--- a/app/lib/graph/entity_extractor.rb
+++ b/app/lib/graph/entity_extractor.rb
@@ -6,9 +6,9 @@ module Graph
     end
 
     def extract(chunk)
-      if chunk.content.size < minimum_chunk_size
+      if chunk.excerpt.size < minimum_chunk_size
         Rails.logger.info(
-          "Chunk #{chunk.id} is too small to extract entities (#{chunk.content.size} < #{minimum_chunk_size})"
+          "Chunk #{chunk.id} is too small to extract entities (#{chunk.excerpt.size} < #{minimum_chunk_size})"
         )
         return
       end
@@ -71,7 +71,7 @@ module Graph
     end
 
     def entities_for(chunk)
-      entities = client.complete(prompt_for(chunk.content), traceable: chunk)
+      entities = client.complete(prompt_for(chunk.excerpt), traceable: chunk)
 
       Rails.logger.debug { "Extracted entities:\n#{entities}" }
 
@@ -104,7 +104,7 @@ module Graph
     end
 
     def input_text
-      @chunk.content
+      @chunk.excerpt
     end
 
     def minimum_chunk_size

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -10,6 +10,13 @@ class Chunk < ApplicationRecord
   scope :embedded, -> { where.not(vector_id: nil) }
   scope :extracted, ->  { where(entities_extracted: true) }
 
+  # Require embedding content when creating new chunks
+  # Schema doesn't enforce presence for backwards compatibility with existing data
+  validate :has_explicit_embedding_content?, on: :create
+
+  # Ensure that someone can't change a previously set embedding content back to `nil`
+  attr_readonly :embedding_content
+
   def previous(count = 1)
     self.class.where(document:).where("id < ?", id).order(id: :asc).last(count)
   end
@@ -21,6 +28,14 @@ class Chunk < ApplicationRecord
   def embedding_content
     # This will help with any previously ingested documents which will
     # have a nil for this column
-    self[:embedding_content] || content
+    self[:embedding_content] || excerpt
+  end
+
+  private
+
+  def has_explicit_embedding_content?
+    return if self[:embedding_content]
+
+    errors.add(:embedding_content, "New chunks require embedding content")
   end
 end

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -16,6 +16,7 @@ class Chunk < ApplicationRecord
 
   # Ensure that someone can't change a previously set embedding content back to `nil`
   attr_readonly :embedding_content
+  attr_readonly :excerpt, :surrounding_content, :location_summary, :headings
 
   def previous(count = 1)
     self.class.where(document:).where("id < ?", id).order(id: :asc).last(count)

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -12,7 +12,7 @@ class Chunk < ApplicationRecord
 
   # Require embedding content when creating new chunks
   # Schema doesn't enforce presence for backwards compatibility with existing data
-  validate :has_explicit_embedding_content?, on: :create
+  validate :explicit_embedding_content?, on: :create
 
   # Ensure that someone can't change a previously set embedding content back to `nil`
   attr_readonly :embedding_content
@@ -33,8 +33,8 @@ class Chunk < ApplicationRecord
 
   private
 
-  def has_explicit_embedding_content?
-    return if self[:embedding_content]
+  def explicit_embedding_content?
+    return false if self[:embedding_content]
 
     errors.add(:embedding_content, "New chunks require embedding content")
   end

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -14,10 +14,6 @@ class Chunk < ApplicationRecord
   # Schema doesn't enforce presence for backwards compatibility with existing data
   validate :explicit_embedding_content?, on: :create
 
-  # Ensure that someone can't change a previously set embedding content back to `nil`
-  attr_readonly :embedding_content
-  attr_readonly :excerpt, :surrounding_content, :location_summary, :headings
-
   def previous(count = 1)
     self.class.where(document:).where("id < ?", id).order(id: :asc).last(count)
   end

--- a/app/services/chunk_document.rb
+++ b/app/services/chunk_document.rb
@@ -11,7 +11,12 @@ class ChunkDocument
     parser.chunks.each do |chunk_record|
       chunk = Chunk.create!(
         document: @document,
-        content: chunk_record.content,
+
+        excerpt: chunk_record.excerpt,
+        headings: chunk_record.headings,
+        location_summary: chunk_record.location_summary,
+        surrounding_content: chunk_record.surrounding_content,
+        embedding_content: chunk_record.embedding_content,
         embedding_content: chunk_record.embedding_content)
 
       EmbedChunkJob.perform_async(chunk.id)

--- a/app/services/chunk_document.rb
+++ b/app/services/chunk_document.rb
@@ -7,7 +7,14 @@ class ChunkDocument
     reset_document unless @document.created?
 
     @document.chunking!
+    create_chunk_records
+    @document.update(title: parser.title)
+    @document.chunked!
+  end
 
+  private
+
+  def create_chunk_records
     parser.chunks.each do |chunk_record|
       chunk = Chunk.create!(
         document: @document,
@@ -21,13 +28,7 @@ class ChunkDocument
 
       EmbedChunkJob.perform_async(chunk.id)
     end
-
-    @document.update(title: parser.title)
-
-    @document.chunked!
   end
-
-  private
 
   def reset_document
     Rails.logger.warn("RESETTING DOCUMENT #{@document.id}: is in state #{@document.state}...")

--- a/app/services/chunk_document.rb
+++ b/app/services/chunk_document.rb
@@ -23,7 +23,6 @@ class ChunkDocument
         headings: chunk_record.headings,
         location_summary: chunk_record.location_summary,
         surrounding_content: chunk_record.surrounding_content,
-        embedding_content: chunk_record.embedding_content,
         embedding_content: chunk_record.embedding_content)
 
       EmbedChunkJob.perform_async(chunk.id)

--- a/app/services/chunk_document.rb
+++ b/app/services/chunk_document.rb
@@ -7,14 +7,14 @@ class ChunkDocument
     reset_document unless @document.created?
 
     @document.chunking!
-    create_chunk_records
+    create_chunks
     @document.update(title: parser.title)
     @document.chunked!
   end
 
   private
 
-  def create_chunk_records
+  def create_chunks
     parser.chunks.each do |chunk_record|
       chunk = Chunk.create!(
         document: @document,

--- a/app/services/chunkers/basic_character_chunker.rb
+++ b/app/services/chunkers/basic_character_chunker.rb
@@ -33,7 +33,9 @@ module Chunkers
         chunk = overlap_prev_chunk(chunk, raw_chunks[idx - 1]) if idx.positive?
         chunk = overlap_next_chunk(chunk, raw_chunks[idx + 1]) if idx < (raw_chunks.length - 1)
 
-        overlapped_chunks << ChunkRecord.new(content: chunk)
+        # Intentionally using the overlapping "surrounding content" as the excerpt
+        # for now ... backwards compatibility
+        overlapped_chunks << ChunkRecord.new(excerpt: chunk)
       end
 
       overlapped_chunks
@@ -56,7 +58,7 @@ module Chunkers
     end
 
     def chunk_records(raw_chunks)
-      raw_chunks.map { |chunk| ChunkRecord.new(content: chunk) }
+      raw_chunks.map { |chunk| ChunkRecord.new(excerpt: chunk) }
     end
   end
 end

--- a/app/services/chunkers/basic_image_chunker.rb
+++ b/app/services/chunkers/basic_image_chunker.rb
@@ -10,8 +10,7 @@ module Chunkers
     # Return Enumerable with single chunk
     def chunk(parser)
       [ChunkRecord.new(
-        content: parser.text,
-        embedding_content: '')]
+        excerpt: parser.text)]
     end
   end
 end

--- a/app/services/chunkers/chunk_record.rb
+++ b/app/services/chunkers/chunk_record.rb
@@ -3,16 +3,27 @@ module Chunkers
   # embedding. If a chunk record is created without a separately specific `embedding_content`,
   # the `content`` is used instead.
   class ChunkRecord
-    attr_reader :content
+    attr_reader :excerpt, :surrounding_content, :headings, :location_summary
 
-    def initialize(content:, embedding_content: nil)
-      @content = content
-      @embedding_content = embedding_content
+    def initialize(excerpt:, surrounding_content: nil, headings: nil, location_summary: nil)
+      @excerpt = excerpt
+      @surrounding_content = surrounding_content || excerpt
+      @headings = headings
+      @location_summary = location_summary
     end
 
     def embedding_content
-      # Use content as the key for embedding if no separate key specified
-      @embedding_content || content
+      # Assemble the embedding content used to generate the
+      # vector embeddings
+      text = ""
+      if headings
+        text << headings << "\n"
+      end
+      if location_summary
+        text << location_summary << "\n"
+      end
+      # Use document excerpt if no surrounding content provided (compatibility)
+      text << (surrounding_content || excerpt) << "\n"
     end
   end
 end

--- a/app/services/chunkers/chunk_record.rb
+++ b/app/services/chunkers/chunk_record.rb
@@ -17,13 +17,13 @@ module Chunkers
       # vector embeddings
       text = ""
       if headings
-        text << headings << "\n"
+        text << headings << "\n\n"
       end
       if location_summary
-        text << location_summary << "\n"
+        text << location_summary << "\n\n"
       end
       # Use document excerpt if no surrounding content provided (compatibility)
-      text << (surrounding_content || excerpt) << "\n"
+      text << (surrounding_content || excerpt)
     end
   end
 end

--- a/app/services/chunkers/recursive_text_chunker.rb
+++ b/app/services/chunkers/recursive_text_chunker.rb
@@ -53,7 +53,9 @@ module Chunkers
 
     def chunk(parser)
       raw_chunks_from(parser).map do |c|
-        ChunkRecord.new(content: c[:text])
+        # Intentionally using the overlapping "surrounding content" as the excerpt
+        # for now ... backwards compatibility
+        ChunkRecord.new(excerpt: c[:text])
       end
     end
 

--- a/app/services/embed_chunk.rb
+++ b/app/services/embed_chunk.rb
@@ -17,7 +17,7 @@ class EmbedChunk
   def embed
     embedding = embedder.embed(@chunk.embedding_content)
 
-    ids = chromadb.add_documents(@collection_id, [@chunk.content], [embedding])
+    ids = chromadb.add_documents(@collection_id, [@chunk.embedding_content], [embedding])
     @chunk.update!(vector_id: ids.first)
 
     @document.touch(:updated_at)

--- a/app/services/search/search_hit.rb
+++ b/app/services/search/search_hit.rb
@@ -25,6 +25,7 @@ module Search
 
     def content
       return @reference.content if @reference.respond_to?(:content)
+      return @reference.excerpt if @reference.respond_to?(:excerpt)
 
       @reference.summary if @reference.respond_to?(:summary)
     end

--- a/app/views/chunks/_chunk.html.erb
+++ b/app/views/chunks/_chunk.html.erb
@@ -5,8 +5,8 @@
   <div class="flex w-full flex-1 items-center px-6 py-5 my-3 rounded-md shadow-lg bg-secondary-200 dark:bg-secondary-900 <%= extra_classes %>">
     <div class="pr-20 flex-col text-right">
       <%= chunk.id %>
-      <p class="py-1 text-xs text-right text-muted"><%= chunk ? number_to_human_size(chunk.content.size) : "?" %></p>
-      <%= render "shared/copy_button", content: chunk.content.strip %>
+      <p class="py-1 text-xs text-right text-muted"><%= chunk ? number_to_human_size(chunk.excerpt.size) : "?" %></p>
+      <%= render "shared/copy_button", content: chunk.excerpt.strip %>
     </div>
     <div class="flex-1 whitespace-pre-line">
       <p><%= chunk.embedding_content %></p>

--- a/app/views/messages/_chunk.html.erb
+++ b/app/views/messages/_chunk.html.erb
@@ -4,7 +4,7 @@
   <div class="flex-1 whitespace-prewrap">
     <div class="flex flex-col">
       <div class="pb-4">Chunk #<%= chunk.id%></div>
-      <div><%= chunk.content %></div>
+      <div><%= chunk.excerpt %></div>
     </div>
     
   </div>
@@ -13,10 +13,10 @@
     <% if distance %>
       <div class="py-1">distance: <%= distance.round(1) %></div>
     <% end %>
-    <div class="py-1"><%= chunk ? number_to_human_size(chunk.content.size) : "?" %></div>
+    <div class="py-1"><%= chunk ? number_to_human_size(chunk.excerpt.size) : "?" %></div>
     <div class="py-1"><%= chunk ? time_ago_in_words(chunk.created_at) : "?" %> ago</div>
     <div class="py-1" class="p-4 text-right">
-      <%= render "shared/copy_button", content: chunk.content.strip %>
+      <%= render "shared/copy_button", content: chunk.excerpt.strip %>
     </div>
   </div>
   <% end %>

--- a/app/views/shared/_chunk.html.erb
+++ b/app/views/shared/_chunk.html.erb
@@ -2,14 +2,14 @@
   <%= link_to collection_document_chunk_path(chunk.collection, chunk.document, chunk),
     class: "flex justify-start items-center px-3 py-1 rounded-lg hover:bg-secondary-200 hover:dark:bg-secondary-700 w-full" do %>
   <div class="flex-1 whitespace-prewrap">
-    <%= chunk&.content || "Missing chunk!" %>
+    <%= chunk&.excerpt || "Missing chunk!" %>
   </div>
   <div class="flex flex-col ms-4">
     <p class="py-1 text-xs text-right text-muted"><%= chunk ? chunk.document.filename : "?" %></p>
     <% if distance %>
       <p class="py-1 text-xs text-right text-muted">distance: <%= distance.round(1) %></p>
     <% end %>
-    <p class="py-1 text-xs text-right text-muted"><%= chunk ? number_to_human_size(chunk.content.size) : "?" %></p>
+    <p class="py-1 text-xs text-right text-muted"><%= chunk ? number_to_human_size(chunk.excerpt.size) : "?" %></p>
     <p class="py-1 text-xs text-right text-muted"><%= chunk ? time_ago_in_words(chunk.created_at) : "?" %> ago</p>
   </div>
   <% end %>

--- a/db/migrate/20241103180146_add_more_context_to_chunk.rb
+++ b/db/migrate/20241103180146_add_more_context_to_chunk.rb
@@ -1,0 +1,7 @@
+class AddMoreContextToChunk < ActiveRecord::Migration[7.1]
+  def change
+    add_column :chunks, :headings, :string
+    add_column :chunks, :location_summary, :string
+    add_column :chunks, :surrounding_content, :string
+  end
+end

--- a/db/migrate/20241103190426_rename_content_to_excerpt_in_chunk.rb
+++ b/db/migrate/20241103190426_rename_content_to_excerpt_in_chunk.rb
@@ -1,0 +1,9 @@
+class RenameContentToExcerptInChunk < ActiveRecord::Migration[7.1]
+  def up
+    rename_column :chunks, :content, :excerpt
+  end
+
+  def down
+    rename_column :chunks, :excerpt, :content
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_30_122945) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_03_190426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,12 +72,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_30_122945) do
   create_table "chunks", force: :cascade do |t|
     t.bigint "document_id", null: false
     t.string "vector_id"
-    t.string "content"
+    t.string "excerpt"
     t.jsonb "embeddings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "embedding_content"
     t.boolean "entities_extracted", default: false
+    t.string "headings"
+    t.string "location_summary"
+    t.string "surrounding_content"
     t.index ["document_id"], name: "index_chunks_on_document_id"
   end
 

--- a/spec/factories/chunks.rb
+++ b/spec/factories/chunks.rb
@@ -2,7 +2,10 @@ FactoryBot.define do
   factory :chunk do
     document { association(:document) }
     vector_id { SecureRandom.uuid }
-    content { Faker::Lorem.sentence(word_count: 10) }
-    embedding_content { Faker::Lorem.sentence(word_count: 16) }
+    excerpt { Faker::Lorem.sentence(word_count: 10) }
+    headings { Faker::Lorem.sentence(word_count: 10) }
+    surrounding_content { Faker::Lorem.sentence(word_count: 20) }
+    location_summary { Faker::Lorem.sentence(word_count: 10) }
+    embedding_content { Faker::Lorem.sentence(word_count: 40) }
   end
 end

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -1,60 +1,82 @@
 require 'rails_helper'
 
 RSpec.describe Chunk do
-  subject { create(:chunk, content: "subject", embedding_content:) }
+  subject { create(:chunk, excerpt:, embedding_content:) }
 
   let(:document) { create(:document) }
-  let(:embedding_content) { nil }
+  let(:excerpt) { "subject" }
+  let(:embedding_content) { "surround subject sound" }
   let(:chunks) { document.chunks.sort }
 
-  before do
-    create(:chunk, document:)
-    create(:chunk, document:)
-    document.chunks << subject
-    create(:chunk, document:)
-    create(:chunk, document:)
+  describe "creating a chunk" do
+    context "without embedding_content" do
+      let(:embedding_content) { nil }
 
-    document.reload
-  end
-
-  describe "#previous" do
-    it "returns the previous chunk" do
-      expect(subject.previous).to contain_exactly(chunks[1])
-    end
-
-    it "returns multiple chunks" do
-      expect(subject.previous(2)).to eq(chunks[0..1])
-    end
-
-    it "stops at the beginning of the list" do
-      expect(subject.previous(3)).to eq(chunks[0..1])
+      it "fails" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
   end
 
-  describe "#next" do
-    it "returns the next chunk" do
-      expect(subject.next).to contain_exactly(chunks[-2])
+  context "when using chunks" do
+    before do
+      create(:chunk, document:)
+      create(:chunk, document:)
+      document.chunks << subject
+      create(:chunk, document:)
+      create(:chunk, document:)
+
+      document.reload
     end
 
-    it "returns multiple chunks" do
-      expect(subject.next(2)).to eq(chunks[3..4])
+    describe "#previous" do
+      it "returns the previous chunk" do
+        expect(subject.previous).to contain_exactly(chunks[1])
+      end
+
+      it "returns multiple chunks" do
+        expect(subject.previous(2)).to eq(chunks[0..1])
+      end
+
+      it "stops at the beginning of the list" do
+        expect(subject.previous(3)).to eq(chunks[0..1])
+      end
     end
 
-    it "stops at the end of the list" do
-      expect(subject.next(3)).to eq(chunks[3..4])
-    end
-  end
+    describe "#next" do
+      it "returns the next chunk" do
+        expect(subject.next).to contain_exactly(chunks[-2])
+      end
 
-  describe "#embedding_content" do
-    it "returns the content" do
-      expect(subject.embedding_content).to eq("subject")
+      it "returns multiple chunks" do
+        expect(subject.next(2)).to eq(chunks[3..4])
+      end
+
+      it "stops at the end of the list" do
+        expect(subject.next(3)).to eq(chunks[3..4])
+      end
     end
 
-    context "when embedding_content is set" do
-      let(:embedding_content) { "subject subject subject" }
+    describe "#embedding_content=" do
+      it "fails since property is readonly" do
+        expect { subject.embedding_content = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
+      end
+    end
+
+    describe "#embedding_content" do
+      # context "when embedding_content is not set" do
+      #   before do
+      #     chunk = subject
+      #     chunk.embedding_content = nil
+      #   end
+
+      #   it "returns the excerpt" do
+      #     expect(subject.embedding_content).to eq(excerpt)
+      #   end
+      # end
 
       it "returns the embedding content" do
-        expect(subject.embedding_content).to eq("subject subject subject")
+        expect(subject.embedding_content).to eq("surround subject sound")
       end
     end
   end

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -63,6 +63,30 @@ RSpec.describe Chunk do
       end
     end
 
+    describe "#excerpt=" do
+      it "fails since property is readonly" do
+        expect { subject.excerpt = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
+      end
+    end
+
+    describe "#location_summary=" do
+      it "fails since property is readonly" do
+        expect { subject.location_summary = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
+      end
+    end
+
+    describe "#surrounding_content=" do
+      it "fails since property is readonly" do
+        expect { subject.surrounding_content = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
+      end
+    end
+
+    describe "#headings=" do
+      it "fails since property is readonly" do
+        expect { subject.headings = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
+      end
+    end
+
     describe "#embedding_content" do
       # context "when embedding_content is not set" do
       #   before do

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Chunk do
   let(:embedding_content) { "surround subject sound" }
   let(:chunks) { document.chunks.sort }
 
-  describe "creating a chunk" do
+  describe "#create!" do
     context "without embedding_content" do
       let(:embedding_content) { nil }
 

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -57,47 +57,17 @@ RSpec.describe Chunk do
       end
     end
 
-    describe "#embedding_content=" do
-      it "fails since property is readonly" do
-        expect { subject.embedding_content = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
-      end
-    end
-
-    describe "#excerpt=" do
-      it "fails since property is readonly" do
-        expect { subject.excerpt = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
-      end
-    end
-
-    describe "#location_summary=" do
-      it "fails since property is readonly" do
-        expect { subject.location_summary = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
-      end
-    end
-
-    describe "#surrounding_content=" do
-      it "fails since property is readonly" do
-        expect { subject.surrounding_content = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
-      end
-    end
-
-    describe "#headings=" do
-      it "fails since property is readonly" do
-        expect { subject.headings = nil }.to raise_error(ActiveRecord::ReadonlyAttributeError)
-      end
-    end
-
     describe "#embedding_content" do
-      # context "when embedding_content is not set" do
-      #   before do
-      #     chunk = subject
-      #     chunk.embedding_content = nil
-      #   end
+      context "when embedding_content is nil" do
+        before do
+          chunk = subject
+          chunk.update_attribute(:embedding_content, nil)
+        end
 
-      #   it "returns the excerpt" do
-      #     expect(subject.embedding_content).to eq(excerpt)
-      #   end
-      # end
+        it "returns the excerpt" do
+          expect(subject.embedding_content).to eq(excerpt)
+        end
+      end
 
       it "returns the embedding content" do
         expect(subject.embedding_content).to eq("surround subject sound")

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Chunk do
       context "when embedding_content is nil" do
         before do
           chunk = subject
-          chunk.update_attribute(:embedding_content, nil)
+          chunk.embedding_content = nil
         end
 
         it "returns the excerpt" do

--- a/spec/requests/chunks_spec.rb
+++ b/spec/requests/chunks_spec.rb
@@ -28,7 +28,10 @@ RSpec.describe "Chunks" do
         expect(response.parsed_body["chunks"].first).to eq({
           "id" => chunk_one.id,
           "document" => chunk_one.document_id,
-          "content" => chunk_one.content,
+          "excerpt" => chunk_one.excerpt,
+          "headings" => chunk_one.headings,
+          "location_summary" => chunk_one.location_summary,
+          "surrounding_content" => chunk_one.surrounding_content,
           "embedding_content" => chunk_one.embedding_content,
           "entities_extracted" => chunk_one.entities_extracted,
           "vector_id" => chunk_one.vector_id,
@@ -38,7 +41,10 @@ RSpec.describe "Chunks" do
         expect(response.parsed_body["chunks"].second).to eq({
           "id" => chunk_two.id,
           "document" => chunk_two.document_id,
-          "content" => chunk_two.content,
+          "excerpt" => chunk_two.excerpt,
+          "headings" => chunk_two.headings,
+          "location_summary" => chunk_two.location_summary,
+          "surrounding_content" => chunk_two.surrounding_content,
           "embedding_content" => chunk_two.embedding_content,
           "entities_extracted" => chunk_two.entities_extracted,
           "vector_id" => chunk_two.vector_id,

--- a/spec/services/api/generate_search_results_spec.rb
+++ b/spec/services/api/generate_search_results_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Api::GenerateSearchResults do
       expect(subject.search(query)).to eq([
         {
           id: chunks.first.id,
-          document: chunks.first.content,
+          document: chunks.first.excerpt,
           metadata: "",
           distance: hits.first.distance,
           vector_id: chunks.first.vector_id,
@@ -59,7 +59,7 @@ RSpec.describe Api::GenerateSearchResults do
         },
         {
           id: chunks.second.id,
-          document: chunks.second.content,
+          document: chunks.second.excerpt,
           metadata: "",
           distance: hits.third.distance,
           vector_id: chunks.second.vector_id,

--- a/spec/services/graph/entity_extractor_spec.rb
+++ b/spec/services/graph/entity_extractor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Graph::EntityExtractor do
       sound emanating from the muffled engine.
     CHUNK
   end
-  let(:chunk) { create(:chunk, content: chunk_content) }
+  let(:chunk) { create(:chunk, excerpt: chunk_content) }
   let(:completion) do
     <<~COMPLETION
       ("entity" | "Minnie M. Baxter" | "organization" | "Minnie M. Baxter is the name of the barge owned by Skippy and his father.")##

--- a/spec/services/prompt_augmentor_spec.rb
+++ b/spec/services/prompt_augmentor_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe PromptAugmentor do
         <<~PROMPT
           Here is some context that may help you answer the following question:
 
-          #{chunks.first.content}
+          #{chunks.first.excerpt}
 
-          #{chunks.second.content}
+          #{chunks.second.excerpt}
 
           Question: What tool should I use to install Ruby?
         PROMPT

--- a/spec/support/api/schemas/chunks.json
+++ b/spec/support/api/schemas/chunks.json
@@ -8,16 +8,22 @@
           "id",
           "document",
           "vector_id",
-          "content",
+          "excerpt",
           "embedding_content",
-          "entities_extracted"
+          "entities_extracted",
+          "headings",
+          "location_summary",
+          "surrounding_content"
         ],
         "properties": {
           "id": { "type": "integer" },
           "document": { "type": "integer" },
           "vector_id": { "type": "string" },
-          "content": { "type": "string" },
+          "excerpt": { "type": "string" },
           "embedding_content": { "type": ["string", null] },
+          "headings": { "type": ["string", null] },
+          "location_summary": { "type": ["string", null] },
+          "surrounding_content": { "type": ["string", null] },
           "entities_extracted": { "type": "boolean" },
           "created_at": { "type": "string", "format": "date-time" },
           "updated_at": { "type": "string", "format": "date-time" }

--- a/spec/support/shared_examples/services/chunkers/chunkers_with_overlap.rb
+++ b/spec/support/shared_examples/services/chunkers/chunkers_with_overlap.rb
@@ -6,8 +6,8 @@ RSpec.shared_examples "chunkers supporting overlap" do
   describe "#chunk" do
     context "with overlap" do
       it "returns chunks no bigger than 'chunk_size + chunk_overlap'" do
-        expect(chunks.first.content.size).to be <= chunk_size + chunk_overlap
-        expect(chunks.last.content.size).to be <= chunk_size + chunk_overlap
+        expect(chunks.first.surrounding_content.size).to be <= chunk_size + chunk_overlap
+        expect(chunks.last.surrounding_content.size).to be <= chunk_size + chunk_overlap
       end
     end
 
@@ -15,8 +15,8 @@ RSpec.shared_examples "chunkers supporting overlap" do
       let(:chunk_overlap) { 0 }
 
       it "returns chunks no bigger than 'chunk_size'" do
-        expect(chunks.first.content.size).to be <= chunk_size
-        expect(chunks.last.content.size).to be <= chunk_size
+        expect(chunks.first.surrounding_content.size).to be <= chunk_size
+        expect(chunks.last.surrounding_content.size).to be <= chunk_size
       end
     end
   end


### PR DESCRIPTION
The crux of this PR is as follows:

In `Chunk` and `ChunkRecord`
- rename `content` to `excerpt` - this will be the document's excerpt represented by the chunk
- add `surrounding_content` - this will be the version of the excerpt with any additional prefix and suffix text if there's any overlap criteria used by the chunker
- add `headings` - the location of the excerpt based on previous headings
- add `location_summary` - some text that describes the chunk's "location" within the document.
- retain `embedding_content` - this will be used to store the input (calculated based on above properties) to the embeddings that is used in the similarity search

All the other changes are a result of making the code compatible with the above changes. 

Not all the new properties are in use yet; the current changes preserve backwards compatibility with any previously ingested content. 