### PR TITLE
Define Mediator to help dispatch document ingest

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -37,11 +37,7 @@ class DocumentsController < ApplicationController
   end
 
   def vectorize
-    if @document.web?
-      FetchWebDocumentJob.perform_async(@document.id)
-    else
-      ChunkDocumentJob.perform_async(@document.id)
-    end
+    Mediator.ingest(@document)
   end
 
   def stop

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -21,15 +21,8 @@ class DocumentsController < ApplicationController
 
   def create
     @chunking_profile = ChunkingProfile.find_or_create_by(chunking_params)
-
     @document = document_from_params
-
-    if @document.web?
-      FetchWebDocumentJob.perform_async(@document.id)
-    else
-      ChunkDocumentJob.perform_async(@document.id)
-    end
-
+    Mediator.ingest(@document)
     redirect_to @document.collection
   end
 

--- a/app/jobs/fetch_web_document_job.rb
+++ b/app/jobs/fetch_web_document_job.rb
@@ -12,7 +12,6 @@ class FetchWebDocumentJob
     document = Document.find(document_id)
 
     FetchWebDocument.new(document).execute
-
-    ChunkDocumentJob.perform_async(document.id) unless document.errored?
+    Mediator.ingest(document) unless document.errored?
   end
 end

--- a/app/services/mediator.rb
+++ b/app/services/mediator.rb
@@ -4,7 +4,7 @@ module Mediator
   def self.ingest(document)
     if document.filename.nil?
       # Document has no file, so kick off fetching if it's a link
-      raise DocumentHasNoFile, "No file exists: #{document.name}" unless document.web?
+      raise DocumentHasNoFile, "No file exists, file name is nil" unless document.web?
 
       FetchWebDocumentJob.perform_async(document.id)
     else

--- a/app/services/mediator.rb
+++ b/app/services/mediator.rb
@@ -4,7 +4,7 @@ module Mediator
   def self.ingest(document)
     if document.file.nil?
       # Document has no file, so kick off fetching if it's a link
-      raise DocumentHasNoFile, "No file exists: #{docunemt.name}" unless document.web?
+      raise DocumentHasNoFile, "No file exists: #{document.name}" unless document.web?
 
       FetchWebDocumentJob.perform_async(document.id)
     else

--- a/app/services/mediator.rb
+++ b/app/services/mediator.rb
@@ -2,7 +2,7 @@ module Mediator
   class DocumentHasNoFile < StandardError; end
 
   def self.ingest(document)
-    if document.file.nil?
+    if document.filename.nil?
       # Document has no file, so kick off fetching if it's a link
       raise DocumentHasNoFile, "No file exists: #{document.name}" unless document.web?
 

--- a/app/services/mediator.rb
+++ b/app/services/mediator.rb
@@ -1,0 +1,15 @@
+module Mediator
+  class DocumentHasNoFile < StandardError; end
+
+  def self.ingest(document)
+    if document.file.nil?
+      # Document has no file, so kick off fetching if it's a link
+      raise DocumentHasNoFile, "No file exists: #{docunemt.name}" unless document.web?
+
+      FetchWebDocumentJob.perform_async(document.id)
+    else
+      # Document has a file, so kick off chunking
+      ChunkDocumentJob.perform_async(document.id)
+    end
+  end
+end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,13 +3,14 @@ FactoryBot.define do
     chunks { [] }
     user { association(:user) }
     collection { association(:collection) }
-    filename { "gnu_manifesto.md" }
+    link { "https://www.gnu.org/gnu/manifesto.html" }
+    filename { "spec/fixtures/files/gnu_manifesto.md" }
     state { :chunked }
     vector_id { nil } # TODO: we probably don't need this
     chunking_profile { association(:chunking_profile) }
 
     trait :with_file do
-      file { Rails.root.join("spec/fixtures/files/small_doc.md") }
+      file { Rails.root.join(filename) }
     end
   end
 end

--- a/spec/jobs/fetch_web_document_job_spec.rb
+++ b/spec/jobs/fetch_web_document_job_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe FetchWebDocumentJob do
+  subject { described_class.new }
+
+  let(:collection) { create(:collection) }
+  let(:user) { create(:user) }
+  let(:file) { nil }
+  let(:filename) { nil }
+  let(:link) { nil }
+  let(:chunking_method) { :basic }
+  let(:chunking_profile) { create(:chunking_profile, method: chunking_method, size: 800) }
+  let(:doc) { create(:document, state: :created, link:, file:, filename:, chunking_profile:, collection:, user:) }
+
+  describe "#perform" do
+    context "with document with web link" do
+      let(:link) { "https://en.wikipedia.org/wiki/Tabloid_journalism" }
+
+      before do
+        allow(Mediator).to receive("ingest")
+      end
+
+      it "fetches web page" do
+        subject.perform(doc.id)
+
+        expect(Mediator).to have_received("ingest").with(doc)
+      end
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,5 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe Document do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { described_class.new(state: :created, link:, file:, filename:, chunking_profile:, collection:, user:) }
+
+  let(:collection) { create(:collection) }
+  let(:user) { create(:user) }
+  let(:file) { nil }
+  let(:filename) { nil }
+  let(:link) { nil }
+  let(:chunking_method) { :basic }
+  let(:chunking_profile) { create(:chunking_profile, method: chunking_method, size: 800) }
+
+  describe "when document has a web link" do
+    let(:link) { "https://en.wikipedia.org/wiki/Tabloid_journalism" }
+
+    it "#web? is true" do
+      expect(subject.web?).to be true
+    end
+
+    it "#file is not attached" do
+      expect(subject.file.attached?).to be false
+    end
+
+    it "#filename is nil" do
+      expect(subject.filename).to be_nil
+    end
+  end
+
+  describe "when document has a file" do
+    let(:file) { fixture_file_upload("gnu_manifesto.md", 'application/html') }
+    let(:filename) { "spec/fixtures/files/gnu_manifesto.md" }
+
+    it "#web? is false" do
+      expect(subject.web?).to be false
+    end
+
+    it "#file is attached" do
+      expect(subject.file.attached?).to be true
+    end
+
+    it "#filename is present" do
+      expect(subject.filename).not_to be_nil
+    end
+  end
 end

--- a/spec/services/mediator_spec.rb
+++ b/spec/services/mediator_spec.rb
@@ -14,30 +14,14 @@ RSpec.describe Mediator do
     context "with web link" do
       let(:link) { "https://en.wikipedia.org/wiki/Tabloid_journalism" }
 
-      it "fetches web page" do
-        # Catching the message seems to prevent the actual method from being called
-        # So limiting this to example
+      before do
         allow(FetchWebDocumentJob).to receive("perform_async")
+      end
 
+      it "fetches web page" do
         subject.ingest(doc)
 
         expect(FetchWebDocumentJob).to have_received("perform_async").with(doc.id)
-      end
-
-      context "when web page has been fetched" do
-        before do
-          allow(ChunkDocumentJob).to receive("perform_async")
-        end
-
-        it "chunks document" do
-          subject.ingest(doc)
-
-          # Need to drain to cause the job to be run so I can check if the
-          # chunking job was initiated after fetching
-          FetchWebDocumentJob.drain
-
-          expect(ChunkDocumentJob).to have_received("perform_async").with(doc.id)
-        end
       end
     end
 

--- a/spec/services/mediator_spec.rb
+++ b/spec/services/mediator_spec.rb
@@ -11,31 +11,23 @@ RSpec.describe Mediator do
   let(:doc) { Document.new(state: :created, link:, file:, filename:, chunking_profile:, collection:, user:) }
 
   describe "#ingest document" do
-    after do
-      FetchWebDocumentJob.clear
-      ChunkDocumentJob.clear
-    end
-
     context "with web link" do
       let(:link) { "https://en.wikipedia.org/wiki/Tabloid_journalism" }
-      # let(:doc) { create(:document, state: :created, filename: nil, link: "https://en.wikipedia.org/wiki/Tabloid_journalism", chunking_profile:) }
 
       it "fetches web page" do
         expect do
           subject.ingest(doc)
         end.to change(FetchWebDocumentJob.jobs, :size).by(1)
+        Sidekiq::Worker.clear_all
       end
 
       context "when web page has been fetched" do
-        before do
-          allow(Document).to receive(:find).and_return(doc)
-        end
-
         it "chunks document" do
-          expect do
-            subject.ingest(doc)
-            FetchWebDocumentJob.drain
-          end.to change(ChunkDocumentJob.jobs, :size).by(1)
+          doc.save
+          subject.ingest(doc)
+
+          expect { FetchWebDocumentJob.drain }.to change(ChunkDocumentJob.jobs, :size).by(1)
+          Sidekiq::Worker.clear_all
         end
       end
     end
@@ -43,12 +35,12 @@ RSpec.describe Mediator do
     context "with filename" do
       let(:file) { fixture_file_upload("gnu_manifesto.md", 'application/html') }
       let(:filename) { "spec/fixtures/files/gnu_manifesto.md" }
-      # let(:doc) { create(:document, state: :created, filename: "spec/fixtures/files/gnu_manifesto.md", chunking_profile:) }
 
       it "chunks document" do
         expect do
           subject.ingest(doc)
         end.to change(ChunkDocumentJob.jobs, :size).by(1)
+        Sidekiq::Worker.clear_all
       end
     end
   end

--- a/spec/services/mediator_spec.rb
+++ b/spec/services/mediator_spec.rb
@@ -8,26 +8,35 @@ RSpec.describe Mediator do
   let(:link) { nil }
   let(:chunking_method) { :basic }
   let(:chunking_profile) { create(:chunking_profile, method: chunking_method, size: 800) }
-  let(:doc) { Document.new(state: :created, link:, file:, filename:, chunking_profile:, collection:, user:) }
+  let(:doc) { create(:document, state: :created, link:, file:, filename:, chunking_profile:, collection:, user:) }
 
   describe "#ingest document" do
     context "with web link" do
       let(:link) { "https://en.wikipedia.org/wiki/Tabloid_journalism" }
 
       it "fetches web page" do
-        expect do
-          subject.ingest(doc)
-        end.to change(FetchWebDocumentJob.jobs, :size).by(1)
-        Sidekiq::Worker.clear_all
+        # Catching the message seems to prevent the actual method from being called
+        # So limiting this to example
+        allow(FetchWebDocumentJob).to receive("perform_async")
+
+        subject.ingest(doc)
+
+        expect(FetchWebDocumentJob).to have_received("perform_async").with(doc.id)
       end
 
       context "when web page has been fetched" do
+        before do
+          allow(ChunkDocumentJob).to receive("perform_async")
+        end
+
         it "chunks document" do
-          doc.save
           subject.ingest(doc)
 
-          expect { FetchWebDocumentJob.drain }.to change(ChunkDocumentJob.jobs, :size).by(1)
-          Sidekiq::Worker.clear_all
+          # Need to drain to cause the job to be run so I can check if the
+          # chunking job was initiated after fetching
+          FetchWebDocumentJob.drain
+
+          expect(ChunkDocumentJob).to have_received("perform_async").with(doc.id)
         end
       end
     end
@@ -36,11 +45,20 @@ RSpec.describe Mediator do
       let(:file) { fixture_file_upload("gnu_manifesto.md", 'application/html') }
       let(:filename) { "spec/fixtures/files/gnu_manifesto.md" }
 
-      it "chunks document" do
-        expect do
-          subject.ingest(doc)
-        end.to change(ChunkDocumentJob.jobs, :size).by(1)
-        Sidekiq::Worker.clear_all
+      before do
+        allow(ChunkDocumentJob).to receive("perform_async")
+      end
+
+      it "chunks document without web fetch needed" do
+        subject.ingest(doc)
+
+        expect(ChunkDocumentJob).to have_received("perform_async").with(doc.id)
+      end
+    end
+
+    context "without filename or web link" do
+      it "raises error" do
+        expect { subject.ingest(doc) }.to raise_error(Mediator::DocumentHasNoFile)
       end
     end
   end

--- a/spec/services/mediator_spec.rb
+++ b/spec/services/mediator_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Mediator do
+  subject { described_class }
+
+  let(:collection) { create(:collection) }
+  let(:user) { create(:user) }
+  let(:file) { nil }
+  let(:filename) { nil }
+  let(:link) { nil }
+  let(:chunking_method) { :basic }
+  let(:chunking_profile) { create(:chunking_profile, method: chunking_method, size: 800) }
+  let(:doc) { Document.new(state: :created, link:, file:, filename:, chunking_profile:, collection:, user:) }
+
+  describe "#ingest document" do
+    after do
+      FetchWebDocumentJob.clear
+      ChunkDocumentJob.clear
+    end
+
+    context "with web link" do
+      let(:link) { "https://en.wikipedia.org/wiki/Tabloid_journalism" }
+      # let(:doc) { create(:document, state: :created, filename: nil, link: "https://en.wikipedia.org/wiki/Tabloid_journalism", chunking_profile:) }
+
+      it "fetches web page" do
+        expect do
+          subject.ingest(doc)
+        end.to change(FetchWebDocumentJob.jobs, :size).by(1)
+      end
+
+      context "when web page has been fetched" do
+        before do
+          allow(Document).to receive(:find).and_return(doc)
+        end
+
+        it "chunks document" do
+          expect do
+            subject.ingest(doc)
+            FetchWebDocumentJob.drain
+          end.to change(ChunkDocumentJob.jobs, :size).by(1)
+        end
+      end
+    end
+
+    context "with filename" do
+      let(:file) { fixture_file_upload("gnu_manifesto.md", 'application/html') }
+      let(:filename) { "spec/fixtures/files/gnu_manifesto.md" }
+      # let(:doc) { create(:document, state: :created, filename: "spec/fixtures/files/gnu_manifesto.md", chunking_profile:) }
+
+      it "chunks document" do
+        expect do
+          subject.ingest(doc)
+        end.to change(ChunkDocumentJob.jobs, :size).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created `Mediator` service to handle the ingest document workflow. The name is a play on "media" since this service will handle taking a document through it's various stages depending on its media type.

For now
- if document has no filename
  - if document has a web link
    - dispatch a `FetchWebDocumentJob`
  - else raise error
- else
  - dispatch a `ChunkDocumentJob`

In addition, the `FetchWebDocumentJob` now calls the `Mediator.ingest` after it completes downloading the link. Currently, this triggers chunking, but over time we can handle more interim steps before chunking depending on the document's media type.
