### PR TITLE
fix error when proxying message when no collections to search

### DIFF
--- a/app/services/message_augmentor.rb
+++ b/app/services/message_augmentor.rb
@@ -15,9 +15,9 @@ class MessageAugmentor
   private
 
   def collections_to_search
-    @collections_to_search ||= if @conversation.search_collections
-      message_collections = @conversation.collections
-      message_collections.any? ? message_collections : @conversation.user.collections
+    @collections_to_search ||= if @conversation.search_collections?
+      conversation_collections = @conversation.collections
+      conversation_collections.any? ? conversation_collections : @conversation.user.collections
     else
       []
     end

--- a/app/services/ollama_proxy/chat_message.rb
+++ b/app/services/ollama_proxy/chat_message.rb
@@ -7,7 +7,7 @@ module OllamaProxy
 
     def content
       # the first attempt to find content in the message works with Ollama's OpenAI chat route
-      # the second attempt works with the Ollama's chat route
+      # the second attempt works with Ollama's chat route
       @content ||= if @provider == :ollama
         @message_hash["content"]
       elsif @provider == :openai

--- a/app/services/ollama_proxy/formatted_chat_response.rb
+++ b/app/services/ollama_proxy/formatted_chat_response.rb
@@ -35,6 +35,7 @@ module OllamaProxy
     def extract_content(chunk)
       response_hash = parse_chunk(chunk)
 
+      # TODO: raise the error, don't return it as content
       content = response_hash.dig("message", "content") ||
         response_hash.dig("choices", 0, "delta", "content") ||
         response_hash.dig("choices", 0, "message", "content") ||

--- a/spec/e2e/opp/chat_spec.rb
+++ b/spec/e2e/opp/chat_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "opp/api/chat", :chat, :llm, :now, :opp, :slow, type: :system do
+RSpec.describe "opp/api/chat", :chat, :llm, :opp, :slow, type: :system do
   let(:call) { opp_post("/api/chat", payload) }
   let(:payload) do
     {
@@ -8,7 +8,7 @@ RSpec.describe "opp/api/chat", :chat, :llm, :now, :opp, :slow, type: :system do
       messages: [
         {
           role: "user",
-          content: "Who started the GNU Project?",
+          content: "hello",
         },
       ],
     }.to_json

--- a/spec/e2e/opp/completions_spec.rb
+++ b/spec/e2e/opp/completions_spec.rb
@@ -49,4 +49,28 @@ RSpec.describe "opp/v1/chat/completions", :chat, :llm, :opp, :slow, type: :syste
       expect(call).to have_chunks_matching_schema("opp/completion_chunk")
     end
   end
+
+  context "when empty system message is included" do
+    let(:payload) do
+      {
+        model: "llama3.1:latest",
+        stream: true,
+        messages: [
+          {
+            role: "system",
+            content: "",
+          },
+          {
+            role: "user",
+            content: "why is the sky blue?",
+          },
+        ],
+      }
+    end
+
+    it "returns a chat response", :now do
+      expect(call.code).to eq(200)
+      expect(call).to have_chunks_matching_schema("opp/completion_chunk")
+    end
+  end
 end

--- a/spec/factories/conversation_collections.rb
+++ b/spec/factories/conversation_collections.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :conversation_collection do
+    conversation { association(:conversation) }
+    collection { association(:collection) }
+  end
+end

--- a/spec/factories/conversations.rb
+++ b/spec/factories/conversations.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
         build(:message, author: user, content: "Not exactly what I meant."),
       ]
     end
+    search_collections { true }
 
     factory :augmented_conversation do
       messages do
@@ -26,6 +27,10 @@ FactoryBot.define do
           ),
         ]
       end
+    end
+
+    factory :conversation_with_collection do
+      conversation_collections { [build(:conversation_collection)] }
     end
   end
 end

--- a/spec/services/message_augmentor_spec.rb
+++ b/spec/services/message_augmentor_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe MessageAugmentor do
+  subject { described_class.new(message) }
+
+  let(:message) { conversation.messages.last }
+  let(:conversation) { create(:conversation_with_collection, search_collections:, conversation_collections:) }
+  let(:search_collections) { true }
+  let(:conversation_collections) { [build(:conversation_collection, collection:)] }
+  let(:collection) { create(:collection) }
+
+  let(:searchn) { instance_double(Search::SearchN, search: search_hits) }
+  let(:search_hits) do
+    [
+      Search::SearchHit.new(chunks[0], 200.0),
+      Search::SearchHit.new(chunks[1], 220.0),
+    ]
+  end
+  let(:chunks) { create_list(:chunk, 2, document:) }
+  let(:document) { create(:document, collection:) }
+
+  let(:prompt_augmentor) { instance_double(PromptAugmentor, augment: nil) }
+
+  before do
+    allow(Search::SearchN).to receive(:new).and_return(searchn)
+    allow(PromptAugmentor).to receive(:new).and_return(prompt_augmentor)
+  end
+
+  shared_examples "searches collections" do
+    it "calls PromptAugmentor" do
+      subject.execute
+      expect(PromptAugmentor).to have_received(:new).with(message, search_hits)
+      expect(prompt_augmentor).to have_received(:augment).with(no_args)
+    end
+
+    it "calls Search::SearchN" do
+      subject.execute
+      expect(Search::SearchN).to have_received(:new).with(
+        containing_exactly(collection),
+        num_results: 10,
+        traceable: conversation
+      )
+      expect(searchn).to have_received(:search).with(message.content)
+    end
+  end
+
+  describe "#execute" do
+    include_examples "searches collections"
+
+    context "when search is disabled for conversation" do
+      let(:search_collections) { false }
+
+      it "does not call PromptAugmentor" do
+        subject.execute
+        expect(PromptAugmentor).not_to have_received(:new)
+      end
+
+      it "does not search collections" do
+        subject.execute
+        expect(Search::SearchN).not_to have_received(:new)
+      end
+    end
+
+    context "when conversation has no associated collections" do
+      let(:conversation_collections) { [] }
+
+      include_examples "searches collections"
+    end
+  end
+end

--- a/spec/services/ollama_proxy/chat_request_spec.rb
+++ b/spec/services/ollama_proxy/chat_request_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe OllamaProxy::ChatRequest do
     end
   end
 
+  # this came from HF chat-ui in the wild, was causing a problem
+  shared_context "when empty system message is included" do
+    let(:raw_post) do
+      {
+        model: "llama3.1:latest",
+        stream: true,
+        messages: [
+          { role: "system", content: "" },
+          { role: "user", content: "why is the sky blue?" },
+        ],
+      }.to_json
+    end
+  end
+
   include_context "when messages are in Ollama format"
 
   describe "#model" do
@@ -59,6 +73,18 @@ RSpec.describe OllamaProxy::ChatRequest do
           "",
         ])
         expect(subject.messages.map(&:role)).to eq(%w[user assistant user])
+      end
+    end
+
+    context "when empty system message is included" do
+      include_context "when empty system message is included"
+
+      it "returns the messages from the request body" do
+        expect(subject.messages.map(&:content)).to eq([
+          "",
+          "why is the sky blue?",
+        ])
+        expect(subject.messages.map(&:role)).to eq(%w[system user])
       end
     end
   end

--- a/spec/services/ollama_proxy/conversation_finder_spec.rb
+++ b/spec/services/ollama_proxy/conversation_finder_spec.rb
@@ -135,5 +135,22 @@ RSpec.describe OllamaProxy::ConversationFinder do
         end
       end
     end
+
+    context "when an empty system message is present" do
+      let(:raw_post) do
+        {
+          model: "llama3",
+          messages: [
+            { role: "system", content: "" },
+            { role: "user", content: "why is the sky blue?" },
+          ],
+        }.to_json
+      end
+
+      it "creates one message" do
+        expect { subject.find_or_create }.to change(Message, :count).by(1)
+        expect(Message.last.content).to eq("why is the sky blue?")
+      end
+    end
   end
 end


### PR DESCRIPTION
- add a bunch of tests, trying to find a bug
- clean up an unused method
- clarify a variable name
- fix a bug in which OPP would send Ollama a message with `content: nil` if there were no collections to search on the request