### PR TITLE
fix seed error removing duplicate settings

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -174,7 +174,7 @@ end
 Setting.all.each do |setting|
   settings_with_same_key = Setting.where(key: setting.key).order(updated_at: :desc)
   settings_with_same_key.where(value: nil).each(&:destroy!)
-  settings_with_same_key[1..-1].each(&:destroy!)
+  settings_with_same_key[1..-1]&.each(&:destroy!)
 end
 # DEV
 #

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -170,12 +170,6 @@ Setting.find_or_create_by!(key: "system_prompt") do |setting|
   PROMPT
 end
 
-# deduplicate settings - just added validation and some DBs have duplicate keys
-Setting.all.each do |setting|
-  settings_with_same_key = Setting.where(key: setting.key).order(updated_at: :desc)
-  settings_with_same_key.where(value: nil).each(&:destroy!)
-  settings_with_same_key[1..-1]&.each(&:destroy!)
-end
 # DEV
 #
 if Rails.env == "development"


### PR DESCRIPTION
- remove deduplication of Settings

It was required when making Setting validation stricter, but it no longer required. In addition, it doesn't respect `target`, so it could actually remove settings that are associated with a specific model, once we start using those.