### PR TITLE
Responsive chat

### DIFF
--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -5,8 +5,5 @@ export default class extends Controller {
   toggle(event) {
     const sidebar = document.getElementById("sidebar");
     sidebar.classList.toggle("hidden");
-
-    const nav = document.getElementById("sidebar-menu-button");
-    nav.classList.toggle("hidden");
   }
 }

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="sidebar"
+export default class extends Controller {
+  toggle(event) {
+    const sidebar = document.getElementById("sidebar");
+    sidebar.classList.toggle("hidden");
+
+    const nav = document.getElementById("sidebar-menu-button");
+    nav.classList.toggle("hidden");
+  }
+}

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -1,4 +1,8 @@
-<div id="conversation">
+<div id="conversation" class="h-screen overflow-x-hidden overflow-y-scroll no-scrollbar">
+  <nav id="sidebar-menu-button" class="bg-secondary-100 dark:bg-secondary-900 sticky w-full top-0 left-0 lg:hidden text-2xl text-secondary-800 dark:text-secondary-200 py-2 px-5">
+    <%= render "shared/title", classes: "text-primary-600 dark:text-primary-400" %>
+  </nav>
+
   <div class="flex flex-col items-center">
     <div class="flex flex-col items-center px-4 w-[450px] sm:w-full md:w-full lg:w-[768px] xl:w-[900px]">
       <div class="pb-5 w-full">

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -14,7 +14,7 @@
           <%= render @conversation.messages.order(:created_at) %>
         </div>
 
-        <div class="w-full">
+        <div class="w-full py-5">
           <%= render "messages/form" %>
         </div>
 

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -1,21 +1,21 @@
 <div id="conversation">
   <div class="flex flex-col items-center">
-    <div class="w-3/4 flex flex-col items-center">
-      <div class="flex-1 pb-5">
+    <div class="flex flex-col items-center px-4 w-[450px] sm:w-full md:w-full lg:w-[768px] xl:w-[900px]">
+      <div class="pb-5 w-full">
         <%= render "conversation_form" %>
       </div>
 
-    <div class="container flex flex-col items-center rounded-lg flex-start">
-        <div id="messages" class="w-full">
+      <div class="flex flex-col rounded-lg w-full">
+        <div id="messages">
           <%= render @conversation.messages.order(:created_at) %>
         </div>
 
-        <div class="py-5 w-full">
+        <div class="w-full">
           <%= render "messages/form" %>
         </div>
 
         <div id="end-of-conversation">
-    </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/conversations/_conversation_form.html.erb
+++ b/app/views/conversations/_conversation_form.html.erb
@@ -1,46 +1,59 @@
 <% conversation ||= @conversation %>
-<div class="flex" id="conversation_form">
-  <%= form_for conversation do |f| %>
-    <%= f.text_field(
-      :title,
-      class: "rounded-md bg-secondary-200 dark:bg-secondary-800 mx-1",
-      value: conversation.title,
-      onchange: "this.form.requestSubmit()"
-    )%>
-    <% if conversation.model_config.available? %>
-      <%= f.collection_select(:model_config_id, model_config_list, :id, :name, {}, {
-        class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 mr-2",
-        onchange: "this.form.requestSubmit()",
-        disabled: conversation.messages.any? ? true : false,
-        title: conversation.messages.any? ? "The model cannot be changed after the conversation has started." : ""
-      })%>
-    <% else %>
-      <%= f.collection_select(:model_config_id, [conversation.model_config], :id, :name, {}, {
-        class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 mr-2",
-        onchange: "this.form.requestSubmit()",
-        disabled: true,
-        title: "This model is no longer available."
-      })%>
-    <% end %>
-    <label class="inline-flex items-center cursor-pointer mr-2 mb-1 px-2 align-middle border border-secondary-400 rounded-lg h-full dark:bg-secondary-800">
-      <%= f.check_box :search_collections, value: "", class: "sr-only peer", onchange: "this.form.requestSubmit()" %>
-      <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-300 dark:peer-focus:ring-primary-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary-600"></div>
-      <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Search collections</span>
-    </label>
-    <%= f.submit "Update", hidden: true %>
-  <% end %>
 
-  <%= form_with url: conversation_collections_path, method: :post do |f|%>
-    <% selected_collection_id = conversation.collections&.first&.id %>
-    <%= f.collection_select(:collection_ids, collection_list(conversation.user), :id, :name, {
-      selected: selected_collection_id,
-      prompt: "All collections",
-    }, {
-      class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 mr-2 w-64",
-      onchange: "this.form.requestSubmit()",
-      disabled: conversation.messages.any? ? true : false
-    })%>
-    <%= f.text_field :conversation_id, value: conversation.id, type: :hidden %>
-    <%= f.submit "Update", hidden: true %>
-  <% end %>
+<div id="conversation_form">
+  <div class="flex w-full justify-center">
+    <%= form_for conversation do |f| %>
+      <%= f.text_field(
+        :title,
+        class: "border-0 border-b-2 bg-secondary-50 dark:bg-secondary-950 m-2 px-5 w-[400px] sm:w-[550px]",
+        value: conversation.title,
+        onchange: "this.form.requestSubmit()"
+      )%>
+      <%= f.submit "Update", hidden: true %>
+    <% end %>
+  </div>
+  <div class="flex flex-col sm:flex-row justify-center">
+    <%= form_for conversation do |f| %>
+      <% if conversation.model_config.available? %>
+        <%= f.collection_select(:model_config_id, model_config_list, :id, :name, {}, {
+          class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 m-2",
+          onchange: "this.form.requestSubmit()",
+          disabled: conversation.messages.any? ? true : false,
+          title: conversation.messages.any? ? "The model cannot be changed after the conversation has started." : ""
+        })%>
+      <% else %>
+        <%= f.collection_select(:model_config_id, [conversation.model_config], :id, :name, {}, {
+          class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 m-2",
+          onchange: "this.form.requestSubmit()",
+          disabled: true,
+          title: "This model is no longer available."
+        })%>
+      <% end %>
+      <%= f.submit "Update", hidden: true %>
+    <% end %>
+    <%= form_for conversation do |f| %>
+      <div class="text-nowrap">
+        <label class="inline-flex items-center cursor-pointer m-2 p-2 align-middle border border-secondary-400 rounded-lg h-full dark:bg-secondary-800">
+          <%= f.check_box :search_collections, value: "", class: "sr-only peer", onchange: "this.form.requestSubmit()" %>
+          <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-300 dark:peer-focus:ring-primary-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary-600"></div>
+          <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Search collections</span>
+        </label>
+      </div>
+      <%= f.submit "Update", hidden: true %>
+    <% end %>
+
+    <%= form_with url: conversation_collections_path, method: :post do |f|%>
+      <% selected_collection_id = conversation.collections&.first&.id %>
+      <%= f.collection_select(:collection_ids, collection_list(conversation.user), :id, :name, {
+        selected: selected_collection_id,
+        prompt: "All collections",
+      }, {
+        class: "rounded-lg text-secondary-800 bg-secondary-200 dark:text-secondary-200 dark:bg-secondary-800 m-2",
+        onchange: "this.form.requestSubmit()",
+        disabled: conversation.messages.any? ? true : false
+      })%>
+      <%= f.text_field :conversation_id, value: conversation.id, type: :hidden %>
+      <%= f.submit "Update", hidden: true %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/conversations/_conversation_list.html.erb
+++ b/app/views/conversations/_conversation_list.html.erb
@@ -1,4 +1,4 @@
-<div id="conversations" class="hidden lg:block overflow-y-scroll overflow-x-hidden no-scrollbar p-4 w-80 h-screen bg-secondary-200 dark:bg-secondary-900 text-secondary-950 dark:text-secondary-100">
+<div id="sidebar" class="hidden lg:block px-5 py-2 w-80 h-screen bg-secondary-200 dark:bg-secondary-900 text-secondary-950 dark:text-secondary-100">
   <div class="container flex flex-col items-center h-full">
     <%= render "shared/title", classes: "text-primary-600 dark:text-primary-400" %>
     <%= button_to "New conversation",

--- a/app/views/conversations/_conversation_list.html.erb
+++ b/app/views/conversations/_conversation_list.html.erb
@@ -1,4 +1,4 @@
-<div id="sidebar" class="hidden lg:block px-5 py-2 w-80 h-screen bg-secondary-200 dark:bg-secondary-900 text-secondary-950 dark:text-secondary-100">
+<div id="sidebar" class="fixed hidden lg:static lg:block px-5 py-2 w-80 h-screen bg-secondary-200 dark:bg-secondary-900 text-secondary-950 dark:text-secondary-100">
   <div class="container flex flex-col items-center h-full">
     <%= render "shared/title", classes: "text-primary-600 dark:text-primary-400" %>
     <%= button_to "New conversation",

--- a/app/views/conversations/_conversation_list.html.erb
+++ b/app/views/conversations/_conversation_list.html.erb
@@ -1,4 +1,4 @@
-<div id="conversations" class="overflow-y-scroll overflow-x-hidden no-scrollbar p-4 w-80 h-screen bg-secondary-200 dark:bg-secondary-900 text-secondary-950 dark:text-secondary-100">
+<div id="conversations" class="hidden lg:block overflow-y-scroll overflow-x-hidden no-scrollbar p-4 w-80 h-screen bg-secondary-200 dark:bg-secondary-900 text-secondary-950 dark:text-secondary-100">
   <div class="container flex flex-col items-center h-full">
     <%= render "shared/title", classes: "text-primary-600 dark:text-primary-400" %>
     <%= button_to "New conversation",

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,18 +1,23 @@
-<div class="flex">
-  <%= render "conversation_list", conversations: @conversations, selected: @conversation %>
+<div class="flex flex-col no-scrollbar">
+  <nav id="conversations-menu-button" class="bg-secondary-100 dark:bg-secondary-900 block lg:hidden text-2xl text-secondary-800 dark:text-secondary-200 py-2 px-5">
+    <i class="fa fa-bars"></i>
+    <span>Archyve</span>
+  </nav>
+  <div class="flex">
+    <%= render "conversation_list", conversations: @conversations, selected: @conversation %>
 
-  <div class="overflow-y-scroll no-scrollbar flex-1 p-5 h-screen w-100 bg-secondary-100 dark:bg-secondary-950 flextext-gray-700 dark:text-secondary-200">
-    <%= render "shared/notice" %>
+    <div class="overflow-x-hidden overflow-y-scroll no-scrollbar flex-1 p-5 h-screen w-100 bg-secondary-100 dark:bg-secondary-950 flextext-gray-700 dark:text-secondary-200">
+      <%= render "shared/notice" %>
 
-    <%= turbo_stream_from user_dom_id("conversations") %>
-    <div class="m-2 h-full">
-      <% if @conversation %>
-        <%= render @conversation %>
-      <% else %>
+      <%= turbo_stream_from user_dom_id("conversations") %>
+      <div class="p-2 h-full">
+        <% if @conversation %>
+          <%= render @conversation %>
+        <% else %>
           <div class="container flex justify-center h-full align-center">
           <%= render "no_conversation" %>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,22 +1,17 @@
-<div class="flex flex-col no-scrollbar">
-  <nav id="conversations-menu-button" class="bg-secondary-100 dark:bg-secondary-900 block lg:hidden text-2xl text-secondary-800 dark:text-secondary-200 py-2 px-5">
-    <%= render "shared/title", classes: "text-primary-600 dark:text-primary-400" %>
-  </nav>
+<div class="flex flex-col">
   <div class="flex">
     <%= render "conversation_list", conversations: @conversations, selected: @conversation %>
 
-    <div class="overflow-x-hidden overflow-y-scroll no-scrollbar flex-1 p-5 h-screen w-100 bg-secondary-100 dark:bg-secondary-950 flextext-gray-700 dark:text-secondary-200">
+    <div class="flex-1 w-100 bg-secondary-100 dark:bg-secondary-950 flextext-gray-700 dark:text-secondary-200">
       <%= render "shared/notice" %>
 
       <%= turbo_stream_from user_dom_id("conversations") %>
-      <div class="p-2 h-full">
-        <% if @conversation %>
-          <%= render @conversation %>
-        <% else %>
-          <div class="container flex justify-center h-full align-center">
-          <%= render "no_conversation" %>
-        <% end %>
-      </div>
+      <% if @conversation %>
+        <%= render @conversation %>
+      <% else %>
+        <div class="container flex justify-center align-center">
+        <%= render "no_conversation" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,7 +1,6 @@
 <div class="flex flex-col no-scrollbar">
   <nav id="conversations-menu-button" class="bg-secondary-100 dark:bg-secondary-900 block lg:hidden text-2xl text-secondary-800 dark:text-secondary-200 py-2 px-5">
-    <i class="fa fa-bars"></i>
-    <span>Archyve</span>
+    <%= render "shared/title", classes: "text-primary-600 dark:text-primary-400" %>
   </nav>
   <div class="flex">
     <%= render "conversation_list", conversations: @conversations, selected: @conversation %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="overflow-x-hidden overflow-y-hidden no-scrollbar">
     <div class="relative w-screen app">
       <%= yield %>
     </div>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -6,7 +6,8 @@
 %>
 
 
-<%= form_with url: conversation_messages_path(@conversation), html: { id: "message_form", class: "my-5 w-full" } do |f| %>
+<%= form_with url: conversation_messages_path(@conversation),
+  html: { id: "message_form", class: "mb-5 w-full" } do |f| %>
   <div class="container flex">
     <div class="flex-1 pr-3">
       <%= f.text_area :content,

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -8,7 +8,7 @@
 
 <%= form_with url: conversation_messages_path(@conversation),
   html: { id: "message_form", class: "mb-5 w-full" } do |f| %>
-  <div class="container flex">
+  <div class="flex w-full">
     <div class="flex-1 pr-3">
       <%= f.text_area :content,
         class: "form-control w-full rounded-lg bg-secondary-50 dark:bg-secondary-900",

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,4 +1,5 @@
 <% message_bg_class = message.author.is_a?(User) ? "bg-secondary-100 dark:bg-secondary-950" : "bg-secondary-200 dark:bg-secondary-900 shadow-lg dark:border dark:border-secondary-800" %>
+
 <%= content_tag :div, id: dom_id(message), class: "py-3 my-10 rounded-lg #{message_bg_class}" do %>
   <div>
     <div class="flex justify-start items-start px-5 py-3">
@@ -7,14 +8,13 @@
       </div>
 
       <div class="flex flex-col ms-4 text-right text-secondary-500 dark:text-secondary-400 overflow-x-hidden">
-        <p class="py-1 text-xs hidden xl:block"><%= author_name_for(message) %></p>
-        <p class="py-1 text-xs hidden xl:block"><%= time_ago_in_words(message.created_at) %> ago</p>
-        <div class="flex flex-col hidden xl:block text-xl p-2 text-secondary-500 dark:text-secondary-400">
-          <div class="flex-1"></div>
+        <div class="py-1 text-xs hidden xl:block"><%= author_name_for(message) %></div>
+        <div class="py-1 text-xs hidden xl:block"><%= time_ago_in_words(message.created_at) %> ago</div>
+        <div class="flex hidden xl:block text-xl p-2 text-secondary-500 dark:text-secondary-400">
           <% if message.author.is_a?(ModelConfig) %>
-            <div class="ml-2 hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/regenerate_button", message: %></div>
+            <div class="hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/regenerate_button", message: %></div>
           <% end %>
-          <div class="ml-2 hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/copy_button", content: message.content.strip %></div>
+          <div class="hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/copy_button", content: message.content.strip %></div>
         </div>
       </div>
     </div>
@@ -57,7 +57,7 @@
           </div>
         <% end %>
       </div>
-      <div class="flex flex-col block xl:hidden text-lg p-2 text-secondary-500 dark:text-secondary-400">
+      <div class="flex block xl:hidden text-lg p-2 text-secondary-500 dark:text-secondary-400">
         <div class="flex-1"></div>
         <% if message.author.is_a?(ModelConfig) %>
           <div class="ml-2 hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/regenerate_button", message: %></div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,15 +6,15 @@
         <%= raw(message.content) %>
       </div>
 
-      <div class="flex flex-col ms-4 text-right text-secondary-500 dark:text-secondary-400">
-        <p class="py-1 text-xs"><%= author_name_for(message) %></p>
-        <p class="py-1 text-xs"><%= time_ago_in_words(message.created_at) %> ago</p>
-        <div class="flex">
+      <div class="flex flex-col ms-4 text-right text-secondary-500 dark:text-secondary-400 overflow-x-hidden">
+        <p class="py-1 text-xs hidden xl:block"><%= author_name_for(message) %></p>
+        <p class="py-1 text-xs hidden xl:block"><%= time_ago_in_words(message.created_at) %> ago</p>
+        <div class="flex flex-col hidden xl:block text-xl p-2 text-secondary-500 dark:text-secondary-400">
           <div class="flex-1"></div>
           <% if message.author.is_a?(ModelConfig) %>
-            <div class="ml-2"><%= render "shared/regenerate_button", message: %></div>
+            <div class="ml-2 hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/regenerate_button", message: %></div>
           <% end %>
-          <div class="ml-2"><%= render "shared/copy_button", content: message.content.strip %></div>
+          <div class="ml-2 hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/copy_button", content: message.content.strip %></div>
         </div>
       </div>
     </div>
@@ -38,21 +38,32 @@
       </div>
     <% end %>
 
-    <% if message.statistics.present? %>
-      <div class="flex justify-start w-full px-5 py-2">
-        <div class="text-xs text-secondary-500 dark:text-secondary-400">
-          elapsed: <%= message.statistics["elapsed_ms"] %>ms |
-          tokens: <%= message.statistics["tokens"] %> |
-          tokens/s: <%= message.statistics["tokens_per_sec"] %>ms |
-          time to first token: <%= message.statistics["time_to_first_token"] %>s |
-          server: <%= message.statistics["server"] %> / <%= message.statistics["provider"] %>
-        </div>
+    <div class="flex px-5">
+      <div class="flex flex-col w-full">
+        <% if message.statistics.present? %>
+          <div class="flex justify-start w-full py-2">
+            <div class="text-xs text-secondary-500 dark:text-secondary-400">
+              elapsed: <%= message.statistics["elapsed_ms"] %>ms |
+              tokens: <%= message.statistics["tokens"] %> |
+              tokens/s: <%= message.statistics["tokens_per_sec"] %>ms |
+              time to first token: <%= message.statistics["time_to_first_token"] %>s |
+              server: <%= message.statistics["server"] %> / <%= message.statistics["provider"] %>
+            </div>
+          </div>
+        <% end %>
+        <% if message.error.present? %>
+          <div class="bg-red-400 px-4 text-secondary-950 dark:bg-red-800 dark:text-secondary-200 text-sm rounded-lg px-2">
+            <%= message.error["message"] %>
+          </div>
+        <% end %>
       </div>
-    <% end %>
-    <% if message.error.present? %>
-      <div class="bg-red-400 mx-4 text-secondary-950 dark:bg-red-800 dark:text-secondary-200 text-sm rounded-lg px-2">
-        <%= message.error["message"] %>
+      <div class="flex flex-col block xl:hidden text-lg p-2 text-secondary-500 dark:text-secondary-400">
+        <div class="flex-1"></div>
+        <% if message.author.is_a?(ModelConfig) %>
+          <div class="ml-2 hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/regenerate_button", message: %></div>
+        <% end %>
+        <div class="ml-2 hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/copy_button", content: message.content.strip %></div>
       </div>
-    <% end %>
+    </div>
   </div>
 <% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,16 +1,16 @@
 <% message_bg_class = message.author.is_a?(User) ? "bg-secondary-100 dark:bg-secondary-950" : "bg-secondary-200 dark:bg-secondary-900 shadow-lg dark:border dark:border-secondary-800" %>
 
-<%= content_tag :div, id: dom_id(message), class: "py-3 my-10 rounded-lg #{message_bg_class}" do %>
+<%= content_tag :div, id: dom_id(message), class: "py-3 lg:my-5 rounded-lg #{message_bg_class}" do %>
   <div>
-    <div class="flex justify-start items-start px-5 py-3">
-      <div class="flex-1 whitespace-prewrap w-full text-lg" data-controller="markdown-text">
+    <div class="flex justify-start items-start px-5">
+      <div class="flex-1 w-full text-lg" data-controller="markdown-text">
         <%= raw(message.content) %>
       </div>
 
       <div class="flex flex-col ms-4 text-right text-secondary-500 dark:text-secondary-400 overflow-x-hidden">
         <div class="py-1 text-xs hidden xl:block"><%= author_name_for(message) %></div>
         <div class="py-1 text-xs hidden xl:block"><%= time_ago_in_words(message.created_at) %> ago</div>
-        <div class="flex hidden xl:block text-xl p-2 text-secondary-500 dark:text-secondary-400">
+        <div class="flex hidden xl:block text-xl text-secondary-500 dark:text-secondary-400">
           <% if message.author.is_a?(ModelConfig) %>
             <div class="hover:text-secondary-700 hover:dark:text-secondary-100"><%= render "shared/regenerate_button", message: %></div>
           <% end %>

--- a/app/views/shared/_copy_button.html.erb
+++ b/app/views/shared/_copy_button.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="clipboard" data-clipboard-success-content-value="Copied!">
+<div data-controller="clipboard" data-clipboard-success-content-value="✔️">
   <input readonly type="hidden" value="<%= content %>" data-clipboard-target="source">
 
   <button type="button" data-action="clipboard#copy" data-clipboard-target="button"><i class="fa fa-copy" title="Copy message text"></i></button>

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,7 +1,7 @@
 <% classes ||= "text-tertiary-600 dark:text-tertiary-400" %>
 
-<div class="flex pb-2 w-full font-mono text-2xl font-bold text-center lg:justify-center">
-  <div class="lg:hidden pr-2">
+<div class="flex w-full font-mono text-2xl font-bold text-center lg:justify-center">
+  <div class="lg:hidden pr-2" data-controller="sidebar" data-action="click->sidebar#toggle">
     <i class="fa fa-bars"></i>
   </div>
   <%= link_to "ARCHYVE", root_path, class: classes %>

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,5 +1,8 @@
 <% classes ||= "text-tertiary-600 dark:text-tertiary-400" %>
 
-<div class="pb-2 w-full font-mono text-2xl font-bold text-center">
+<div class="flex pb-2 w-full font-mono text-2xl font-bold text-center lg:justify-center">
+  <div class="lg:hidden pr-2">
+    <i class="fa fa-bars"></i>
+  </div>
   <%= link_to "ARCHYVE", root_path, class: classes %>
 </div>


### PR DESCRIPTION
- make chat responsive to window width
- make conversation form fields collapse nicely when window is not wide enough
- don't let messages get too wide when window is extra large or wider

It's not a complete implementation of mobile support, because when visiting `/conversations` in a small window there is no way to open the sidebar and create a new conversation. However, this is a step towards mobile support, and has some advantages.