### PR TITLE
hide system prompt in convos by default

### DIFF
--- a/app/javascript/controllers/markdown_text_controller.js
+++ b/app/javascript/controllers/markdown_text_controller.js
@@ -4,14 +4,15 @@ import hljs from "highlight.js";
 
 // Connects to data-controller="markdown-text"
 export default class extends Controller {
-  static values = { updated: String }
+  static values = { updated: String };
 
   updatedValueChanged() {
-    const markdownText = this.element.innerText || ""
-    const html = marked(markdownText, {breaks: true})
-    this.element.innerHTML = html
+    const markdownText = this.element.innerText || "";
+    const html = marked(markdownText, { breaks: true });
+
+    this.element.innerHTML = html;
     this.element.querySelectorAll("code").forEach((block) => {
-      hljs.highlightElement(block)
-    })
+      hljs.highlightElement(block);
+    });
   }
 }

--- a/app/javascript/controllers/toggle_visibility_controller.js
+++ b/app/javascript/controllers/toggle_visibility_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="toggle-visibility"
+export default class extends Controller {
+  toggle(event) {
+    // get all child divs
+    const elements = this.element.getElementsByTagName("div");
+    const parent = this.element;
+
+    for (var element of elements) {
+      // if the div has the 'toggle-visiblity' class, toggle the 'hidden' class
+      if (
+        typeof element.classList !== "undefined" &&
+        element.classList.contains("toggle-visibility") &&
+        element.parentElement === parent
+      ) {
+        element.classList.toggle("hidden");
+      }
+    }
+  }
+}

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -41,5 +41,9 @@ class Message < ApplicationRecord
     nnext
   end
 
+  def system?
+    author_id.nil?
+  end
+
   delegate :user, to: :conversation
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,10 +1,17 @@
 <% message_bg_class = message.author.is_a?(User) ? "bg-secondary-100 dark:bg-secondary-950" : "bg-secondary-200 dark:bg-secondary-900 shadow-lg dark:border dark:border-secondary-800" %>
 
+<% if message.system? %>
+  <div data-controller="toggle-visibility" data-action="click->toggle-visibility#toggle" class="text-sm text-secondary-600 dark:text-secondary-300 px-4 py-2 my-1 rounded-lg border border-secondary-950 dark:border-secondary-800 hover:border-primary-500 cursor-pointer">
+    System message
+    <div class="flex flex-col hidden toggle-visibility">
+<% end %>
+
 <%= content_tag :div, id: dom_id(message), class: "py-3 lg:my-5 rounded-lg #{message_bg_class}" do %>
   <div>
     <div class="flex justify-start items-start px-5">
       <div class="flex-1 w-full text-lg" data-controller="markdown-text">
-        <%= raw(message.content) %>
+<!-- this is at the left so the markdown controller doesn't see a bunch of indents; that will change the formatting -->
+<%= raw(message.content) %>
       </div>
 
       <div class="flex flex-col ms-4 text-right text-secondary-500 dark:text-secondary-400 overflow-x-hidden">
@@ -20,21 +27,21 @@
     </div>
 
     <% if message.prompt %>
-      <div class="text-sm text-secondary-600 dark:text-secondary-300 border border-secondary-300 dark:border-secondary-800 hover:border-primary-500 px-4 py-2 my-1 rounded-lg cursor-pointer">
-        <details>
-          <summary>Augmentations</summary>
-          <div id=<%= "#{dom_id(message)}-augmentations" %> class="flex flex-col">
-            <% message.augmentations.each do |augmentation| %>
-              <%= render partial_for_augmentation(augmentation), chunk: augmentation.augmentation, entity: augmentation.augmentation, distance: augmentation.distance %>
-            <% end %>
-          </div>
-          <details>
-            <summary>Raw prompt</summary>
-            <div class="whitespace-pre-line">
-              <%= message.prompt %>
+      <div data-controller="toggle-visibility" data-action="click->toggle-visibility#toggle" class="text-sm text-secondary-600 dark:text-secondary-300 border border-secondary-300 dark:border-secondary-800 hover:border-primary-500 px-4 py-2 my-1 rounded-lg cursor-pointer">
+          <div>Augmentations</div>
+          <div class="flex flex-col toggle-visibility hidden">
+            <div id=<%= "#{dom_id(message)}-augmentations" %> class="flex flex-col pt-3">
+              <% message.augmentations.each do |augmentation| %>
+                <%= render partial_for_augmentation(augmentation), chunk: augmentation.augmentation, entity: augmentation.augmentation, distance: augmentation.distance %>
+              <% end %>
             </div>
-          </details>
-        </details>
+              <div data-controller="toggle-visibility" data-action="click->toggle-visibility#toggle" class="p-3 rounded-lg border border-secondary-300 dark:border-secondary-900 hover:border-primary-500">
+                Raw prompt
+                <div class="hidden toggle-visibility p-5 whitespace-pre-line">
+                  <%= message.prompt %>
+                </div>
+              </div>
+          </div>
       </div>
     <% end %>
 
@@ -66,4 +73,9 @@
       </div>
     </div>
   </div>
+<% end %>
+
+<% if message.system? %>
+  </div>
+</div>
 <% end %>


### PR DESCRIPTION
- hide system prompt in Conversations by default
- user can click to show the system prompt
- add generic `toggle-visibility` stimulus controller to toggle the visibility of any child `div` with the class `toggle-visibility`
- use `toggle-visibility` stimulus controller to also show and hide "Augmentations" and "Raw prompt"

The idea is that the system prompt could get longer, and it might be surprising to users to see it at the start of a newly-created chat. I think most chat UIs make the system message available, but not shown inline by default.

What do you think, @mattlindsey? Since you just added the system prompt I thought I'd run this by you.

## Default

![image](https://github.com/user-attachments/assets/939b45da-8a92-4b3f-b66c-d90cd3a680ed)

## After clicking

![image](https://github.com/user-attachments/assets/92b00733-c3ea-4611-a7bd-306485127f45)
