### PR TITLE
Add conversion-related states to Document

### DIFF
--- a/app/jobs/convert_document_job.rb
+++ b/app/jobs/convert_document_job.rb
@@ -11,9 +11,11 @@ class ConvertDocumentJob
   def perform(document_id)
     document = Document.find(document_id)
     ResetDocument.new(document).execute
+    document.converting!
     converter = Converters.find(document)
     new_doc = converter.convert
     new_doc.save!
+    document.convert!
     # Pass it back to Mediator for next step
     Mediator.ingest(new_doc) unless new_doc.errored?
   end

--- a/app/services/helpers/document_reset_helper.rb
+++ b/app/services/helpers/document_reset_helper.rb
@@ -18,6 +18,7 @@ module Helpers
       delete_embeddings
       delete_chunks
       delete_graph_entities
+      @document.reset!
     end
 
     private

--- a/app/views/collections/_document.html.erb
+++ b/app/views/collections/_document.html.erb
@@ -20,9 +20,7 @@
           <div class="pb-4 mr-2">
             <%= link_to title_for(document), collection_document_path(document.collection, document), format: :turbo_stream %>
           </div>
-          <% if document.no_children? %>
-            <%= render "shared/document_state_badges", document: %>
-          <% end %>
+          <%= render "shared/document_state_badges", document: %>
         </div>
       </div>
 

--- a/app/views/shared/_document_state_badges.html.erb
+++ b/app/views/shared/_document_state_badges.html.erb
@@ -11,13 +11,15 @@
       <i class="fa fa-circle-info"></i>
     </div>
   <% else %>
-  <div class="rounded-lg text-xs text-secondary-800 dark:text-secondary-200 mx-1 p-1 px-2 <%= state_bg %>">
+    <div class="rounded-lg text-xs text-secondary-800 dark:text-secondary-200 mx-1 p-1 px-2 <%= state_bg %>">
       <%= state_text_for(document) %>
     </div>
   <% end %>
-  <div class="p-1 px-2 mx-1 text-xs rounded-lg text-secondary-800 dark:text-secondary-200 bg-secondary-300 dark:bg-secondary-700">
-    <%= chunks_completed_label_for(total_chunks, embedded_chunks, "embedded") %>
-  </div>
+  <% if document.no_children? && !(document.converting? || document.converted?) %>
+    <div class="p-1 px-2 mx-1 text-xs rounded-lg text-secondary-800 dark:text-secondary-200 bg-secondary-300 dark:bg-secondary-700">
+      <%= chunks_completed_label_for(total_chunks, embedded_chunks, "embedded") %>
+    </div>
+  <% end %>
   <% if document.collection.graph_enabled? %>
     <div class="p-1 px-2 mx-1 text-xs rounded-lg text-secondary-800 dark:text-secondary-200 bg-secondary-300 dark:bg-secondary-700">
       <%= chunks_completed_label_for(total_chunks, extracted_chunks, "extracted") %>

--- a/spec/jobs/convert_document_job_spec.rb
+++ b/spec/jobs/convert_document_job_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe ConvertDocumentJob do
         allow(Mediator).to receive("ingest")
       end
 
+      it "marks document as converted" do
+        subject.perform(doc.id)
+
+        expect(Document.find(doc.id).converted?).to be true
+      end
+
       it "calls Mediator after conversion" do
         subject.perform(doc.id)
 


### PR DESCRIPTION
A small one this time. 😄 

- Add `converting` and `converted` states to `Document`
- Add `converting` and `convert` events
- Ensure conversion job updates state before and after conversion
- Also ... 
  - Hacked `after_update_commit` to call `parent.broadcast_replace if parent` which gets rid of the bug where occasionally the collection view doesn't update. This has the side effect that if a document has multiple children they will cause the entire parent to update. 

> Destroying a document still has inconsistant view update. 
 